### PR TITLE
[CDAP-14587] Make metadata tests wait for async metadata update

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLSystemMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLSystemMetadataTest.java
@@ -41,6 +41,7 @@ public class ETLSystemMetadataTest extends ETLTestBase {
   public void testSearchETLArtifactsWithSystemMetadata() throws Exception {
     MetadataClient metadataClient = new MetadataClient(getClientConfig(), getRestClient());
     String version = getMetaClient().getVersion().getVersion();
+
     ArtifactId batchId = NamespaceId.SYSTEM.artifact("cdap-data-pipeline", version);
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(new MetadataSearchResultRecord(batchId));
     Set<MetadataSearchResultRecord> result =
@@ -48,12 +49,14 @@ public class ETLSystemMetadataTest extends ETLTestBase {
     Assert.assertEquals(expected, result);
     result = searchMetadata(metadataClient, NamespaceId.SYSTEM, "cdap-data-p*", EntityTypeSimpleName.ARTIFACT);
     Assert.assertEquals(expected, result);
+
     ArtifactClient artifactClient = new ArtifactClient(getClientConfig(), getRestClient());
     List<ArtifactSummary> allCorePlugins = artifactClient.listVersions(TEST_NAMESPACE, "core-plugins",
                                                                        ArtifactScope.SYSTEM);
     Assert.assertTrue("Expected at least one core-plugins artifact.", allCorePlugins.size() > 0);
     String corePluginsVersion = allCorePlugins.get(0).getVersion();
     ArtifactId corePlugins = NamespaceId.SYSTEM.artifact("core-plugins", corePluginsVersion);
+
     expected = ImmutableSet.of(new MetadataSearchResultRecord(corePlugins));
     result = searchMetadata(metadataClient, NamespaceId.SYSTEM, "table", EntityTypeSimpleName.ARTIFACT);
     Assert.assertEquals(expected, result);

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataTest.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.apps.metadata;
 
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.client.LineageClient;
 import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.client.ProgramClient;
@@ -128,6 +129,15 @@ public class ProgramMetadataTest extends AudiTestBase {
     getTestManager().addPluginArtifact(pluginArtifact, systemMetadataArtifact,
                                        ArtifactSystemMetadataApp.EchoPlugin1.class,
                                        ArtifactSystemMetadataApp.EchoPlugin2.class);
+
+    // Wait for system metadata to be populated
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(systemMetadataArtifact, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(pluginArtifact, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+
     // verify search using artifact name
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(systemMetadataArtifact)),
@@ -147,6 +157,14 @@ public class ProgramMetadataTest extends AudiTestBase {
   }
 
   private void assertAppSearch() throws Exception {
+    // Wait for system metadata to be populated
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(APP, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(PROGRAM, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+
     // using app name
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(new MetadataSearchResultRecord(APP));
     Assert.assertEquals(expected, searchMetadata(TEST_NAMESPACE, APP.getEntityName(), null));
@@ -162,6 +180,11 @@ public class ProgramMetadataTest extends AudiTestBase {
   }
 
   private void assertProgramSearch() throws Exception {
+    // Wait for system metadata to be populated
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(PROGRAM, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(PROGRAM)),
       searchMetadata(TEST_NAMESPACE, "batch", EntityTypeSimpleName.PROGRAM));
@@ -179,6 +202,14 @@ public class ProgramMetadataTest extends AudiTestBase {
   }
 
   private void assertDatasetSearch() throws Exception {
+    // Wait for system metadata to be populated
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(INPUT_DATASET, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+    Tasks.waitFor(false,
+        () -> metadataClient.getProperties(OUTPUT_DATASET, MetadataScope.SYSTEM).isEmpty(),
+        10, TimeUnit.SECONDS);
+
     // search all entities that have a defined schema
     // add a user property with "schema" as key
     Map<String, String> datasetProperties = ImmutableMap.of("schema", "schemaValue");

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataTest.java
@@ -132,11 +132,11 @@ public class ProgramMetadataTest extends AudiTestBase {
 
     // Wait for system metadata to be populated
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(systemMetadataArtifact, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(systemMetadataArtifact, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(pluginArtifact, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(pluginArtifact, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
 
     // verify search using artifact name
     Assert.assertEquals(
@@ -159,11 +159,11 @@ public class ProgramMetadataTest extends AudiTestBase {
   private void assertAppSearch() throws Exception {
     // Wait for system metadata to be populated
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(APP, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(APP, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(PROGRAM, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(PROGRAM, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
 
     // using app name
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(new MetadataSearchResultRecord(APP));
@@ -182,8 +182,8 @@ public class ProgramMetadataTest extends AudiTestBase {
   private void assertProgramSearch() throws Exception {
     // Wait for system metadata to be populated
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(PROGRAM, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(PROGRAM, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
 
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(PROGRAM)),
@@ -204,11 +204,11 @@ public class ProgramMetadataTest extends AudiTestBase {
   private void assertDatasetSearch() throws Exception {
     // Wait for system metadata to be populated
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(INPUT_DATASET, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(INPUT_DATASET, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
     Tasks.waitFor(false,
-        () -> metadataClient.getProperties(OUTPUT_DATASET, MetadataScope.SYSTEM).isEmpty(),
-        10, TimeUnit.SECONDS);
+                  () -> metadataClient.getProperties(OUTPUT_DATASET, MetadataScope.SYSTEM).isEmpty(),
+                  10, TimeUnit.SECONDS);
 
     // search all entities that have a defined schema
     // add a user property with "schema" as key


### PR DESCRIPTION
after the change in cdap, metadata is now written via TMS, and we need to waitFor() it to show up.