### PR TITLE
Update OperationalStatsTest to remove assertion on streams.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/operations/OperationalStatsTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/operations/OperationalStatsTest.java
@@ -53,8 +53,6 @@ public class OperationalStatsTest extends AudiTestBase {
     Assert.assertTrue(toInt(entities.get("Applications")) >= 0);
     Assert.assertTrue(toInt(entities.get("Programs")) >= 0);
     Assert.assertTrue(toInt(entities.get("Datasets")) >= 0);
-    Assert.assertTrue(toInt(entities.get("Streams")) >= 0);
-    Assert.assertTrue(toInt(entities.get("StreamViews")) >= 0);
     Map<String, Object> connections = cdapStats.get("lasthourload");
     Assert.assertTrue(toLong(connections.get("TotalRequests")) >= 0);
     Assert.assertTrue(toLong(connections.get("Successful")) >= 0);


### PR DESCRIPTION
Only line 57 was failing, but I'm proactively also removing line 56.

Example failure: https://builds.cask.co/browse/IT-ITN-DSTM51-189/test/case/72349325
```
java.lang.NullPointerException: null
	at co.cask.cdap.operations.OperationalStatsTest.toInt(OperationalStatsTest.java:75)
	at co.cask.cdap.operations.OperationalStatsTest.testCDAPStats(OperationalStatsTest.java:57)
```