### PR TITLE
Fix ApplicationTest by migrating it to use an application that doesn't use Flow.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/ApplicationTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/ApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,13 +16,14 @@
 
 package co.cask.cdap.apps;
 
+import co.cask.cdap.apps.fileset.FileSetExample;
+import co.cask.cdap.apps.fileset.FileSetService;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.common.ApplicationNotFoundException;
-import co.cask.cdap.examples.purchase.PurchaseApp;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.AudiTestBase;
-import co.cask.cdap.test.FlowManager;
+import co.cask.cdap.test.ServiceManager;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,18 +37,18 @@ public class ApplicationTest extends AudiTestBase {
 
   @Test
   public void test() throws Exception {
-    ApplicationManager applicationManager = deployApplication(PurchaseApp.class);
-    FlowManager purchaseFlow = applicationManager.getFlowManager("PurchaseFlow").start();
-    purchaseFlow.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    ApplicationManager applicationManager = deployApplication(FileSetExample.class);
+    ServiceManager fileSetService = applicationManager.getServiceManager(FileSetService.class.getSimpleName()).start();
+    fileSetService.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     // should not delete application when programs are running
     ApplicationClient appClient = new ApplicationClient(getClientConfig(), getRestClient());
     try {
-      appClient.delete(TEST_NAMESPACE.app(PurchaseApp.APP_NAME));
+      appClient.delete(TEST_NAMESPACE.app(FileSetExample.NAME));
       Assert.fail();
     } catch (IOException expected) {
       Assert.assertTrue(expected.getMessage().startsWith("409"));
-      Assert.assertTrue(expected.getMessage().contains("PurchaseFlow"));
+      Assert.assertTrue(expected.getMessage().contains("FileSetService"));
     }
 
     // should not delete non-existing application

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/fileset/FileSetExample.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/fileset/FileSetExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,9 +34,11 @@ import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
  */
 public class FileSetExample extends AbstractApplication {
 
+  public static final String NAME = "FileSetExample";
+
   @Override
   public void configure() {
-    setName("FileSetExample");
+    setName(NAME);
     setDescription("Application with a MapReduce that uses a FileSet dataset");
     createDataset("lines", FileSet.class, FileSetProperties.builder()
       .setBasePath("example/data/lines")


### PR DESCRIPTION
Fix ApplicationTest by migrating it to use an application that doesn't use Flow.

Fixes the following failure:
https://builds.cask.co/browse/IT-ITN-DSTH22-204/test/case/72348811

```
java.lang.RuntimeException: java.io.IOException: co.cask.cdap.api.flow.Flow
	at co.cask.cdap.client.util.RESTClient.upload(RESTClient.java:160)
	at co.cask.cdap.client.ApplicationClient.deployApp(ApplicationClient.java:449)
	at co.cask.cdap.client.ApplicationClient.deploy(ApplicationClient.java:377)
	at co.cask.cdap.client.ApplicationClient.deploy(ApplicationClient.java:353)
	at co.cask.cdap.test.IntegrationTestManager.deployApplication(IntegrationTestManager.java:183)
	at co.cask.cdap.test.AbstractTestManager.deployApplication(AbstractTestManager.java:43)
	at co.cask.cdap.test.IntegrationTestBase.deployApplication(IntegrationTestBase.java:374)
	at co.cask.cdap.test.IntegrationTestBase.deployApplication(IntegrationTestBase.java:378)
	at co.cask.cdap.apps.ApplicationTest.test(ApplicationTest.java:39)
```