### PR TITLE
Add dataset test with modified example.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/DatasetTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/DatasetTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.apps.dataset;
+
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.client.DatasetClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.common.UnauthenticatedException;
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.AudiTestBase;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.ServiceManager;
+import co.cask.common.http.HttpMethod;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpResponse;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Integration tests for datasets which tests all the rest endpoints of datasets.
+ */
+public class DatasetTest extends AudiTestBase {
+
+  private static final Gson GSON = new Gson();
+
+  @Test
+  public void test() throws Exception {
+
+    DatasetClient datasetClient = new DatasetClient(getClientConfig(), getRestClient());
+
+    // there should be no datasets in the test namespace
+    Assert.assertEquals(0, datasetClient.list(TEST_NAMESPACE).size());
+
+    ApplicationManager applicationManager = deployApplication(WordCount.class);
+
+    // number of datasets which were created by the wordcount app
+    int appDatasetsCount = datasetClient.list(TEST_NAMESPACE).size();
+
+    // test creating dataset
+    DatasetId testDatasetinstance = TEST_NAMESPACE.dataset("testDataset");
+    datasetClient.create(testDatasetinstance, "table");
+
+    // one more dataset should have been added
+    Assert.assertEquals(appDatasetsCount + 1, datasetClient.list(TEST_NAMESPACE).size());
+
+    // test that properties there is nothing in properties in the new dataset created above
+    DatasetMeta oldMeta = datasetClient.get(testDatasetinstance);
+    Assert.assertEquals(0, oldMeta.getSpec().getProperties().size());
+
+    // update the dataset properties
+    datasetClient.update(testDatasetinstance, ImmutableMap.of("fruit", "mango", "one", "1"));
+
+    // test if properties in meta got updated
+    DatasetMeta newMeta = datasetClient.get(testDatasetinstance);
+    Assert.assertEquals(2, newMeta.getSpec().getProperties().size());
+
+    // test if properties in meta is correct
+    Assert.assertTrue(newMeta.getSpec().getProperties().containsKey("fruit"));
+    Assert.assertTrue(newMeta.getSpec().getProperties().containsKey("one"));
+    Assert.assertEquals("mango", newMeta.getSpec().getProperties().get("fruit"));
+    Assert.assertEquals("1", newMeta.getSpec().getProperties().get("one"));
+
+    // test deleting a datatset
+    datasetClient.delete(testDatasetinstance);
+    Assert.assertEquals(appDatasetsCount, datasetClient.list(TEST_NAMESPACE).size());
+
+    ServiceManager wordCountService = applicationManager.getServiceManager(RetrieveCounts.SERVICE_NAME).start();
+    wordCountService.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+    ingestData();
+
+    Map<String, Object> responseMap = getWordCountStats(wordCountService);
+    Assert.assertEquals(2.0, ((double) responseMap.get("totalWords")), 0);
+    // test truncating a dataset with existing dataset
+    datasetClient.truncate(TEST_NAMESPACE.dataset("wordStats"));
+    // after truncating there should be 0 word
+    responseMap = getWordCountStats(wordCountService);
+    Assert.assertEquals(0, ((double) responseMap.get("totalWords")), 0);
+
+    // test the number of datasets used by an app with existing app
+    Assert.assertEquals(appDatasetsCount, getDatasetInstances(String.format("apps/%s/datasets",
+                                                                            WordCount.class.getSimpleName())).size());
+
+    // test the number of datasets used by an app with non existing app
+    Assert.assertEquals(0, getDatasetInstances(String.format("apps/%s/datasets", "nonExistingApp")).size());
+
+
+    // test datasets used by a program with an existing program
+    Assert.assertEquals(appDatasetsCount, getDatasetInstances(String.format("apps/%s/datasets",
+                                                                            WordCount.class.getSimpleName(),
+                                                                            "WordCounter")).size());
+
+    // test datasets used by a program with a non existing program (one since we write to the dataset with a non
+    // existing program).
+    Assert.assertEquals(1, getDatasetInstances(String.format("apps/%s/datasets",
+                                                             WordCount.class.getSimpleName(),
+                                                             "nonExistingProgram")).size());
+
+    // test programs using a dataset with existing dataset name
+    Assert.assertEquals(2, getPrograms(String.format("data/datasets/%s/programs", "wordStats")).size());
+
+
+    // test programs using a dataset with non existing dataset name
+    Assert.assertEquals(0, getPrograms(String.format("data/datasets/%s/programs",
+                                                     "nonExistingDataset")).size());
+  }
+
+  private Map<String, Object> getWordCountStats(ServiceManager wordCountService) throws Exception {
+    URL url = new URL(wordCountService.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS), "stats");
+    HttpResponse response = getRestClient().execute(HttpRequest.get(url).build(), getClientConfig().getAccessToken());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(),
+                         new TypeToken<Map<String, Object>>() { }.getType());
+  }
+
+  private Set<ProgramId> getPrograms(String endPoint)
+    throws IOException, UnauthenticatedException, UnauthorizedException {
+    HttpResponse response = makeRequest(endPoint);
+    return GSON.fromJson(response.getResponseBodyAsString(),
+                         new TypeToken<Set<ProgramId>>() { }.getType());
+  }
+
+  private Set<DatasetId> getDatasetInstances(String endPoint)
+    throws IOException, UnauthenticatedException, UnauthorizedException {
+    HttpResponse response = makeRequest(endPoint);
+    return GSON.fromJson(response.getResponseBodyAsString(),
+                         new TypeToken<Set<DatasetId>>() { }.getType());
+  }
+
+  private HttpResponse makeRequest(String endPoint)
+    throws IOException, UnauthenticatedException, UnauthorizedException {
+    ClientConfig clientConfig = getClientConfig();
+    URL url = clientConfig.resolveNamespacedURLV3(TEST_NAMESPACE, endPoint);
+    HttpResponse response = getRestClient().execute(HttpMethod.GET, url, clientConfig.getAccessToken());
+    Assert.assertEquals(response.getResponseCode(), HttpURLConnection.HTTP_OK);
+    return response;
+  }
+
+  protected void ingestData() throws Exception {
+    // write input data
+    DataSetManager<Table> datasetManager = getTableDataset("wordStats");
+    Table table = datasetManager.get();
+    Put put = new Put("totals");
+    put.add("total_length", 2L);
+    put.add("total_words", 2L);
+    table.put(put);
+    datasetManager.flush();
+  }
+}

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/RetrieveCounts.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/RetrieveCounts.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.apps.dataset;
+
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.Service;
+
+/**
+ * A {@link Service} to retrieve statistics, word counts and associations.
+ */
+public class RetrieveCounts extends AbstractService {
+
+  public static final String SERVICE_NAME = "RetrieveCounts";
+  private final WordCount.WordCountConfig config;
+
+  public RetrieveCounts(WordCount.WordCountConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  protected void configure() {
+    setName(SERVICE_NAME);
+    setDescription("A service to retrieve statistics, word counts, and associations.");
+    addHandler(new RetrieveCountsHandler(config));
+  }
+}

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/RetrieveCountsHandler.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/RetrieveCountsHandler.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.apps.dataset;
+
+import co.cask.cdap.api.annotation.Property;
+import co.cask.cdap.api.dataset.table.Get;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceContext;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Retrieve Counts service handler.
+ */
+public class RetrieveCountsHandler extends AbstractHttpServiceHandler {
+
+  @Property
+  private final String wordStatsTableName;
+
+
+  private Table wordStatsTable;
+
+
+  public RetrieveCountsHandler(WordCount.WordCountConfig config) {
+    this.wordStatsTableName = config.getWordStatsTable();
+  }
+
+  @Override
+  public void initialize(HttpServiceContext context) throws Exception {
+    super.initialize(context);
+    wordStatsTable = context.getDataset(wordStatsTableName);
+  }
+
+  /**
+   * Returns total number of words, the number of unique words, and the average word length.
+   */
+  @Path("stats")
+  @GET
+  public void getStats(HttpServiceRequest request, HttpServiceResponder responder) {
+    long totalWords = 0L;
+    long uniqueWords = 0L;
+    double averageLength = 0.0;
+
+    // Read the total_length and total_words to calculate average length
+    Row result = wordStatsTable.get(new Get("totals", "total_length", "total_words"));
+    if (!result.isEmpty()) {
+      // Extract the total sum of lengths
+      long totalLength = result.getLong("total_length", 0);
+
+      // Extract the total count of words
+      totalWords = result.getLong("total_words", 0);
+
+      // Compute the average length
+      if (totalLength != 0 && totalWords != 0) {
+        averageLength = ((double) totalLength) / totalWords;
+      }
+    }
+
+    // Return a map as JSON
+    Map<String, Object> results = new HashMap<>();
+    results.put("totalWords", totalWords);
+    results.put("uniqueWords", uniqueWords);
+    results.put("averageLength", averageLength);
+
+    responder.sendJson(results);
+  }
+}
+

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/WordCount.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/dataset/WordCount.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.apps.dataset;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.dataset.table.TableProperties;
+
+/**
+ * Word count sample Application used for integration tests.
+ *
+ */
+public class WordCount extends AbstractApplication<WordCount.WordCountConfig> {
+
+  /**
+   * Word Count Application's configuration class.
+   */
+  public static class WordCountConfig extends Config {
+    private String wordStatsTable;
+
+    /**
+     * Set default values for the configuration variables.
+     */
+    public WordCountConfig() {
+      this.wordStatsTable = "wordStats";
+    }
+
+    /**
+     * Used only for unit testing.
+     */
+    public WordCountConfig(String wordStatsTable) {
+      this.wordStatsTable = wordStatsTable;
+    }
+
+
+    public String getWordStatsTable() {
+      return wordStatsTable;
+    }
+  }
+
+  @Override
+  public void configure() {
+    WordCountConfig config = getConfig();
+    setName("WordCount");
+    setDescription("Example word count application");
+
+    // Store processed data in Datasets
+    createDataset(config.getWordStatsTable(), Table.class,
+                  TableProperties.builder()
+                    .setReadlessIncrementSupport(true)
+                    .setDescription("Stats of total counts and lengths of words")
+                    .build());
+
+    // Retrieve the processed data using a Service
+    addService(new RetrieveCounts(config));
+  }
+}

--- a/integration-test-remote/src/test/java/co/cask/cdap/test/suite/AllTests.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/test/suite/AllTests.java
@@ -39,6 +39,7 @@ import co.cask.cdap.app.serviceworker.ServiceWorkerTest;
 import co.cask.cdap.apps.ApplicationTest;
 import co.cask.cdap.apps.ApplicationVersionTest;
 import co.cask.cdap.apps.NamespaceTest;
+import co.cask.cdap.apps.dataset.DatasetTest;
 import co.cask.cdap.apps.fileset.FileSetTest;
 import co.cask.cdap.apps.fileset.PartitionCorrectorTest;
 import co.cask.cdap.apps.fileset.PartitionedFileSetUpdateTest;
@@ -63,6 +64,7 @@ import org.junit.runners.Suite;
   BatchAggregatorTest.class,
   BatchCubeSinkTest.class,
   BatchJoinerTest.class,
+  DatasetTest.class,
   DataStreamsTest.class,
   ETLMapReduceTest.class,
   ExcelInputReaderTest.class,


### PR DESCRIPTION
This tests all the functionality of the original test, but instead of populating the table via the stream/flow in the example, we simply write to it via AudiTestBase.