### PR TITLE
Change MetadataClient usage, since the API changed

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLSystemMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLSystemMetadataTest.java
@@ -18,9 +18,9 @@ package co.cask.cdap.app.etl;
 
 import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactSummary;
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.client.ArtifactClient;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -48,7 +48,7 @@ public class ETLSystemMetadataTest extends ETLTestBase {
     Set<MetadataSearchResultRecord> result =
       searchMetadata(metadataClient, NamespaceId.SYSTEM, "cdap-data-pipeline", null);
     Assert.assertEquals(expected, result);
-    result = searchMetadata(metadataClient, NamespaceId.SYSTEM, "cdap-data-p*", EntityTypeSimpleName.ARTIFACT);
+    result = searchMetadata(metadataClient, NamespaceId.SYSTEM, "cdap-data-p*", MetadataEntity.ARTIFACT);
     Assert.assertEquals(expected, result);
 
     ArtifactClient artifactClient = new ArtifactClient(getClientConfig(), getRestClient());
@@ -59,7 +59,7 @@ public class ETLSystemMetadataTest extends ETLTestBase {
     ArtifactId corePlugins = NamespaceId.SYSTEM.artifact("core-plugins", corePluginsVersion);
 
     expected = ImmutableSet.of(new MetadataSearchResultRecord(corePlugins));
-    result = searchMetadata(metadataClient, NamespaceId.SYSTEM, "table", EntityTypeSimpleName.ARTIFACT);
+    result = searchMetadata(metadataClient, NamespaceId.SYSTEM, "table", MetadataEntity.ARTIFACT);
     Assert.assertEquals(expected, result);
     // Searching in some user namespace should also surface entities from the system namespace
     expected = ImmutableSet.of(new MetadataSearchResultRecord(
@@ -70,7 +70,7 @@ public class ETLSystemMetadataTest extends ETLTestBase {
 
   private Set<MetadataSearchResultRecord> searchMetadata(MetadataClient metadataClient,
                                                          NamespaceId namespace, String query,
-                                                         @Nullable EntityTypeSimpleName targetType) throws Exception {
+                                                         @Nullable String targetType) throws Exception {
     Set<MetadataSearchResultRecord> results =
       metadataClient.searchMetadata(namespace, query, targetType).getResults();
     Set<MetadataSearchResultRecord> transformed = new HashSet<>();

--- a/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataTest.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/apps/metadata/ProgramMetadataTest.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.apps.metadata;
 
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.client.LineageClient;
 import co.cask.cdap.client.MetadataClient;
@@ -29,7 +30,6 @@ import co.cask.cdap.data2.metadata.lineage.Relation;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
@@ -149,7 +149,7 @@ public class ProgramMetadataTest extends AudiTestBase {
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(pluginArtifact)),
       searchMetadata(TEST_NAMESPACE,
-                     ArtifactSystemMetadataApp.PLUGIN1_NAME, EntityTypeSimpleName.ARTIFACT)
+                     ArtifactSystemMetadataApp.PLUGIN1_NAME, MetadataEntity.ARTIFACT)
     );
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(pluginArtifact)),
@@ -172,13 +172,13 @@ public class ProgramMetadataTest extends AudiTestBase {
     Assert.assertEquals(expected, searchMetadata(TEST_NAMESPACE, APP.getEntityName(), null));
     // using program names
     Assert.assertEquals(expected, searchMetadata(TEST_NAMESPACE, PROGRAM.getEntityName(),
-                                                 EntityTypeSimpleName.APP));
+                                                 MetadataEntity.APPLICATION));
     // using program types
     Assert.assertEquals(
       expected,
       searchMetadata(TEST_NAMESPACE,
                      ProgramType.MAPREDUCE.getPrettyName() + MetadataConstants.KEYVALUE_SEPARATOR + "*",
-                     EntityTypeSimpleName.APP));
+                     MetadataEntity.APPLICATION));
   }
 
   private void assertProgramSearch() throws Exception {
@@ -189,18 +189,18 @@ public class ProgramMetadataTest extends AudiTestBase {
 
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(PROGRAM)),
-      searchMetadata(TEST_NAMESPACE, "batch", EntityTypeSimpleName.PROGRAM));
+      searchMetadata(TEST_NAMESPACE, "batch", MetadataEntity.PROGRAM));
 
     // Using program names
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(PROGRAM)),
-      searchMetadata(TEST_NAMESPACE, PROGRAM.getEntityName(), EntityTypeSimpleName.PROGRAM));
+      searchMetadata(TEST_NAMESPACE, PROGRAM.getEntityName(), MetadataEntity.PROGRAM));
 
     // using program types
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(PROGRAM)),
       searchMetadata(TEST_NAMESPACE, ProgramType.MAPREDUCE.getPrettyName(),
-                     EntityTypeSimpleName.PROGRAM));
+                     MetadataEntity.PROGRAM));
   }
 
   private void assertDatasetSearch() throws Exception {
@@ -227,15 +227,15 @@ public class ProgramMetadataTest extends AudiTestBase {
     Set<MetadataSearchResultRecord> expectedKvTables = ImmutableSet.of(
       new MetadataSearchResultRecord(INPUT_DATASET), new MetadataSearchResultRecord(OUTPUT_DATASET)
     );
-    result = searchMetadata(TEST_NAMESPACE, "batch", EntityTypeSimpleName.DATASET);
+    result = searchMetadata(TEST_NAMESPACE, "batch", MetadataEntity.DATASET);
     Assert.assertEquals(expectedKvTables, result);
-    result = searchMetadata(TEST_NAMESPACE, "explore", EntityTypeSimpleName.DATASET);
+    result = searchMetadata(TEST_NAMESPACE, "explore", MetadataEntity.DATASET);
     Assert.assertEquals(expectedKvTables, result);
     result = searchMetadata(TEST_NAMESPACE, KeyValueTable.class.getName(), null);
     Assert.assertEquals(expectedKvTables, result);
     result = searchMetadata(TEST_NAMESPACE, "type:*", null);
     Assert.assertEquals(expectedKvTables, result);
-    result = searchMetadata(TEST_NAMESPACE, "dataset*", EntityTypeSimpleName.DATASET);
+    result = searchMetadata(TEST_NAMESPACE, "dataset*", MetadataEntity.DATASET);
     Assert.assertEquals(expectedKvTables, result);
 
     result = searchMetadata(TEST_NAMESPACE, INPUT_DATASET.getEntityName(), null);
@@ -245,7 +245,7 @@ public class ProgramMetadataTest extends AudiTestBase {
   }
 
   private Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespace, String query,
-                                                         @Nullable EntityTypeSimpleName targetType) throws Exception {
+                                                         @Nullable String targetType) throws Exception {
     Set<MetadataSearchResultRecord> results =
       metadataClient.searchMetadata(namespace, query, targetType).getResults();
     Set<MetadataSearchResultRecord> transformed = new HashSet<>();


### PR DESCRIPTION
Change MetadataClient usage, as per changes in https://github.com/cdapio/cdap/commit/ec750e04834f7c312b3fe4cdeb694c8d79bea084#diff-b4114e6a647587816791abcd9ef15f72.

Otherwise, builds can fail with compilation errors, such as in https://builds.cask.co/browse/IT-CLD-215/log
or such as in https://builds.cask.co/browse/IT-IIT-285/log