### PR TITLE
Avoid using auth token for REST calls to CDAP Hub.

### DIFF
--- a/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLTestBase.java
+++ b/integration-test-remote/src/test/java/co/cask/cdap/app/etl/ETLTestBase.java
@@ -47,6 +47,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Before;
@@ -156,7 +157,9 @@ public abstract class ETLTestBase extends AudiTestBase {
     String caskMarketURL = cdapConfig.get("market.base.url").getValue();
     URL pluginJsonURL = new URL(String.format("%s/packages/%s/%s/%s-%s.json",
                                               caskMarketURL, packageName, version, pluginName, version));
-    HttpResponse response = getRestClient().execute(HttpMethod.GET, pluginJsonURL, getClientConfig().getAccessToken());
+    // Avoid passing in an authentication token, which results in an auth failure when making requests to
+    // the CDAP Hub. The CDAP Hub is available without any authentication.
+    HttpResponse response = getRestClient().execute(HttpRequest.get(pluginJsonURL).build());
     Assert.assertEquals(200, response.getResponseCode());
 
     // get the artifact 'parents' from the plugin json


### PR DESCRIPTION
HivePluginTest fails across the board after changing to use the new CDAP Hub on GCS: https://builds.cask.co/browse/IT-ITN-281
This is because GCS does not ignore any authentication tokens that are provided in headers, and instead fails the request if they are passed in. The fix is to not pass in any such headers, as Hub does not require authentication.

Test passes after this change: https://builds.cask.co/browse/IT-ITCC9-4