### PR TITLE
bump version attribute for cookbook logic

### DIFF
--- a/conf/cdap.json
+++ b/conf/cdap.json
@@ -8,7 +8,7 @@
         "dataset.executor.container.memory.mb": "1024",
         "messaging.container.memory.mb": "1024"
       },
-      "version": "4.1.0-1"
+      "version": "6.0.0-1"
     },
     "hadoop": {
       "core_site": {

--- a/conf/cdap_mapr.json
+++ b/conf/cdap_mapr.json
@@ -4,7 +4,7 @@
       "cdap_site": {
         "cdap.http.client.read.timeout.ms":"120000"
       },
-      "version": "4.1.0-1"
+      "version": "6.0.0-1"
     },
     "hadoop": {
       "hdfs_site": {

--- a/conf/cdap_sdk.json
+++ b/conf/cdap_sdk.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "cdap": {
-      "version": "5.1.0-1"
+      "version": "6.0.0-1"
     }
   },
   "initial-lease-duration": 82800000


### PR DESCRIPTION
ITN clusters are autobuilt, but there is logic in the cdap cookbook that keys off this version attribute.  Bump it to 6.0 for new cookbook logic.