### PR TITLE
CDAP-15756 GoogleCloudSpannerTest broken due to pubsub dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
       <version>0.53.0-beta</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>opencensus-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15756

In the scope of this PR:

- fixed inability to start spanned tests