### PR TITLE
Create a GCP test suite and fix tests to set project for plugins

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.app.etl;
+package io.cdap.cdap.app.etl.gcp;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -22,7 +22,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.app.etl.ETLTestBase;
 import io.cdap.cdap.datapipeline.SmartWorkflow;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.WorkflowManager;
@@ -52,6 +54,8 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
 
   private static String projectId;
   private static String serviceAccountCredentials;
+  protected static final ArtifactSelectorConfig GOOGLE_CLOUD_ARTIFACT =
+    new ArtifactSelectorConfig("SYSTEM", "google-cloud", "[0.0.0, 100.0.0)");
 
   @BeforeClass
   public static void testDataprocClassSetup() throws IOException {

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GCSTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GCSTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.app.etl;
+package io.cdap.cdap.app.etl.gcp;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
@@ -447,9 +447,10 @@ public class GCSTest extends DataprocETLTestBase {
     String bucket1Name = String.format("%s-1-%s", prefix, UUID.randomUUID());
     String path = String.format("gs://%s/testFolder,gs://%s/testFolder2", bucket1Name, bucket1Name);
     ETLStage cp1 = new ETLStage("gcs-create", new ETLPlugin(GCS_BUCKET_CREATE_PLUGIN_NAME, Action.PLUGIN_TYPE,
-                                                            ImmutableMap.of("projectId", getProjectId(),
+                                                            ImmutableMap.of("project", getProjectId(),
                                                                             "paths", path,
-                                                                            "failIfExists", String.valueOf(true))));
+                                                                            "failIfExists", String.valueOf(true)),
+                                                            GOOGLE_CLOUD_ARTIFACT));
     ETLBatchConfig config = ETLBatchConfig.builder()
       .addStage(cp1)
       .build();
@@ -487,8 +488,9 @@ public class GCSTest extends DataprocETLTestBase {
 
 
     ETLStage cp1 = new ETLStage("gcs-delete", new ETLPlugin(GCS_BUCKET_DELETE_PLUGIN_NAME, Action.PLUGIN_TYPE,
-                                                            ImmutableMap.of("projectId", getProjectId(),
-                                                                            "paths", paths)));
+                                                            ImmutableMap.of("project", getProjectId(),
+                                                                            "paths", paths),
+                                                            GOOGLE_CLOUD_ARTIFACT));
     ETLBatchConfig config = ETLBatchConfig.builder()
       .addStage(cp1)
       .build();
@@ -526,18 +528,20 @@ public class GCSTest extends DataprocETLTestBase {
 
   private ETLStage createCopyStage(String name, String src, String dest, boolean recursive) {
     return new ETLStage(name, new ETLPlugin(GCS_COPY_PLUGIN_NAME, Action.PLUGIN_TYPE,
-                                            ImmutableMap.of("projectId", getProjectId(),
+                                            ImmutableMap.of("project", getProjectId(),
                                                             "sourcePath", src,
                                                             "destPath", dest,
-                                                            "recursive", String.valueOf(recursive))));
+                                                            "recursive", String.valueOf(recursive)),
+                                            GOOGLE_CLOUD_ARTIFACT));
   }
 
   private ETLStage createMoveStage(String name, String src, String dest, boolean recursive) {
     return new ETLStage(name, new ETLPlugin(GCS_MOVE_PLUGIN_NAME, Action.PLUGIN_TYPE,
-                                            ImmutableMap.of("projectId", getProjectId(),
+                                            ImmutableMap.of("project", getProjectId(),
                                                             "sourcePath", src,
                                                             "destPath", dest,
-                                                            "recursive", String.valueOf(recursive))));
+                                                            "recursive", String.valueOf(recursive)),
+                                            GOOGLE_CLOUD_ARTIFACT));
   }
 
   @Test
@@ -624,16 +628,18 @@ public class GCSTest extends DataprocETLTestBase {
                                                    "schema", schema,
                                                    "format", "avro",
                                                    "referenceName", "gcs-input",
-                                                   "projectId", getProjectId(),
-                                                   "path", createPath(bucket, inputBlobName))));
+                                                   "project", getProjectId(),
+                                                   "path", createPath(bucket, inputBlobName)),
+                                                 GOOGLE_CLOUD_ARTIFACT));
 
     ETLStage sink = new ETLStage("GCSSinkStage", new ETLPlugin(SINK_PLUGIN_NAME,
                                                                BatchSink.PLUGIN_TYPE,
                                                                ImmutableMap.of(
                                                                  "path", createPath(bucket, outputBlobName),
                                                                  "format", "json",
-                                                                 "projectId", getProjectId(),
-                                                                 "referenceName", "gcs-output")));
+                                                                 "project", getProjectId(),
+                                                                 "referenceName", "gcs-output"),
+                                                               GOOGLE_CLOUD_ARTIFACT));
 
     ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
@@ -721,16 +727,18 @@ public class GCSTest extends DataprocETLTestBase {
                                                    "schema", sourceSchema,
                                                    "format", "text",
                                                    "referenceName", "gcs-input",
-                                                   "projectId", getProjectId(),
-                                                   "path", createPath(bucket, INPUT_BLOB_NAME))));
+                                                   "project", getProjectId(),
+                                                   "path", createPath(bucket, INPUT_BLOB_NAME)),
+                                                 GOOGLE_CLOUD_ARTIFACT));
 
     ETLStage sink = new ETLStage("FileSinkStage", new ETLPlugin(SINK_PLUGIN_NAME,
                                                                 BatchSink.PLUGIN_TYPE,
                                                                 ImmutableMap.of(
                                                                   "path", createPath(bucket, OUTPUT_BLOB_NAME),
                                                                   "format", "delimited",
-                                                                  "projectId", getProjectId(),
-                                                                  "referenceName", "gcs-output")));
+                                                                  "project", getProjectId(),
+                                                                  "referenceName", "gcs-output"),
+                                                                GOOGLE_CLOUD_ARTIFACT));
 
     ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.cdap.app.etl.batch;
+package io.cdap.cdap.app.etl.gcp;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ByteArray;
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.app.etl.DataprocETLTestBase;
 import io.cdap.cdap.common.ArtifactNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.etl.api.batch.BatchSink;
@@ -220,6 +219,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
   public void testReadAndStoreInNewTable() throws Exception {
     Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_source")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", SOURCE_TABLE_NAME)
@@ -229,6 +229,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
     String nonExistentSinkTableName = "nonexistent_" + UUID.randomUUID().toString().replaceAll("-", "_");
     Map<String, String> sinkProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_sink")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", nonExistentSinkTableName)
@@ -248,6 +249,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
   public void testReadAndStore() throws Exception {
     Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_source")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", SOURCE_TABLE_NAME)
@@ -256,6 +258,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
 
     Map<String, String> sinkProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_sink")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", SINK_TABLE_NAME)
@@ -278,6 +281,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
   @Test
   public void testReadAndStoreInNewTableWithNoSourceSchema() throws Exception {
     Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
+      .put("project", getProjectId())
       .put("referenceName", "spanner_source")
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
@@ -287,6 +291,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
     String nonExistentSinkTableName = "nonexistent_" + UUID.randomUUID().toString().replaceAll("-", "_");
     Map<String, String> sinkProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_sink")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", nonExistentSinkTableName)
@@ -306,6 +311,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
   public void testReadAndStoreWithNoSourceSchema() throws Exception {
     Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_source")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", SOURCE_TABLE_NAME)
@@ -313,6 +319,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
 
     Map<String, String> sinkProperties = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "spanner_sink")
+      .put("project", getProjectId())
       .put("instance", instance.getId().getInstance())
       .put("database", database.getId().getDatabase())
       .put("table", SINK_TABLE_NAME)
@@ -416,9 +423,10 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
                                                Map<String, String> sinkProperties,
                                                String applicationName) throws Exception {
 
-    ArtifactSelectorConfig artifact = new ArtifactSelectorConfig("SYSTEM", "google-cloud", "[0.0.0, 100.0.0)");
-    ETLPlugin sourcePlugin = new ETLPlugin(SPANNER_PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties, artifact);
-    ETLPlugin sinkPlugin = new ETLPlugin(SPANNER_PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties, artifact);
+    ETLPlugin sourcePlugin = new ETLPlugin(SPANNER_PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties,
+                                           GOOGLE_CLOUD_ARTIFACT);
+    ETLPlugin sinkPlugin = new ETLPlugin(SPANNER_PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties,
+                                         GOOGLE_CLOUD_ARTIFACT);
 
     ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(new ETLStage(SPANNER_SOURCE_STAGE_NAME, sourcePlugin))

--- a/integration-test-remote/src/test/java/io/cdap/cdap/test/suite/GCPSuite.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/test/suite/GCPSuite.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.test.suite;
+
+import io.cdap.cdap.test.runner.AutoSuiteRunner;
+import org.junit.runner.RunWith;
+
+/**
+ * Test suite for GCP related tests.
+ */
+@RunWith(AutoSuiteRunner.class)
+@AutoSuiteRunner.Matches(packages = "io.cdap.cdap.app.etl.gcp")
+public class GCPSuite {
+
+}


### PR DESCRIPTION
Fixed the bigtable test to create an instance at the start of the
tests instead of requiring that an instance is already setup.

Added artifact info to all of the pipelines so that they are
viewable through the UI.