### PR TITLE
Increase default program timeout to 120 seconds.

### DIFF
--- a/integration-test-core/src/main/java/io/cdap/cdap/test/AudiTestBase.java
+++ b/integration-test-core/src/main/java/io/cdap/cdap/test/AudiTestBase.java
@@ -72,7 +72,7 @@ public class AudiTestBase extends IntegrationTestBase {
 
   // Used for starting/stop await timeout.
   protected static final int PROGRAM_START_STOP_TIMEOUT_SECONDS =
-    Integer.valueOf(System.getProperty("programTimeout", "60"));
+    Integer.valueOf(System.getProperty("programTimeout", "120"));
   // Amount of time to wait for a program (i.e. Service, or Worker) to process its first event (upon startup).
   // For now, make it same as PROGRAM_START_STOP_TIMEOUT_SECONDS.
   protected static final int PROGRAM_FIRST_PROCESSED_TIMEOUT_SECONDS = PROGRAM_START_STOP_TIMEOUT_SECONDS;


### PR DESCRIPTION
We've noticed Spark streaming program take >60 seconds to go into RUNNING state, where in the previous run, it took ~40 seconds.