### PR TITLE
disable yarn pmem check

### DIFF
--- a/conf/cdap.json
+++ b/conf/cdap.json
@@ -21,7 +21,9 @@
       "yarn_site": {
         "yarn.resourcemanager.delegation.token.renew-interval": "600000",
         "yarn.resourcemanager.delegation.token.max-lifetime": "1200000",
-        "yarn.scheduler.minimum-allocation-mb": "768"
+        "yarn.scheduler.minimum-allocation-mb": "768",
+        "yarn.nodemanager.vmem-check-enabled": "false",
+        "yarn.nodemanager.pmem-check-enabled": "false"
       }
     },
     "hbase": {


### PR DESCRIPTION
CDAP services are getting killed by yarn due to physical memory
constraints. Disable the pmem check to avoid this.