### PR TITLE
CDAP-16429 log a warning if pipeline cleanup fails

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/PubSubTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/PubSubTest.java
@@ -235,8 +235,13 @@ public class PubSubTest extends DataprocETLTestBase {
 
       subscriber.stopAsync().awaitTerminated();
     } finally {
-      sparkManager.stop();
-      sparkManager.waitForRun(ProgramRunStatus.KILLED, 10, TimeUnit.MINUTES);
+      try {
+        sparkManager.stop();
+        sparkManager.waitForStopped(5, TimeUnit.MINUTES);
+      } catch (Exception e) {
+        // don't treat this as a test failure, but log a warning
+        LOG.warn("Pipeline failed to stop gracefully", e);
+      }
     }
   }
 


### PR DESCRIPTION
The pubsub test was flaky because it would occasionally get a 400
error that the pipeline is not running when the stop call is made.
Changed the test to just log a warning in this scenario since the
test was actually successful. CDAP may have some underlying bugs
causing this behavior though.