### PR TITLE
CDAP-16430 fix deploy hub plugin

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/ETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/ETLTestBase.java
@@ -16,24 +16,24 @@
 
 package io.cdap.cdap.app.etl;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.artifact.InvalidArtifactRangeException;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Put;
 import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.app.hub.PluginAttributes;
 import io.cdap.cdap.client.ApplicationClient;
 import io.cdap.cdap.client.ArtifactClient;
 import io.cdap.cdap.client.DatasetClient;
-import io.cdap.cdap.client.config.ConnectionConfig;
+import io.cdap.cdap.common.ArtifactAlreadyExistsException;
 import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.ArtifactRangeNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.UnauthenticatedException;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
@@ -42,11 +42,11 @@ import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
 import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
 import io.cdap.cdap.proto.ConfigEntry;
 import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.artifact.ArtifactRanges;
 import io.cdap.cdap.proto.artifact.PluginSummary;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.test.AudiTestBase;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.junit.Assert;
@@ -54,19 +54,20 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
  * An abstract class for writing etl integration tests. Tests for etl should extend this class.
  */
 public abstract class ETLTestBase extends AudiTestBase {
+  private static final Gson GSON = new Gson();
   protected static final String SOURCE_DATASET = "sourceDataset";
   protected static final Schema DATASET_SCHEMA = Schema.recordOf(
     "event",
@@ -150,62 +151,40 @@ public abstract class ETLTestBase extends AudiTestBase {
     return version;
   }
 
-  protected void installPluginFromMarket(String packageName, String pluginName, String version)
-    throws IOException, UnauthenticatedException {
+  protected void installPluginFromHub(String packageName, String pluginName, String version)
+    throws IOException, UnauthenticatedException, BadRequestException, ArtifactRangeNotFoundException {
     Map<String, ConfigEntry> cdapConfig = getMetaClient().getCDAPConfig();
 
-    String caskMarketURL = cdapConfig.get("market.base.url").getValue();
+    String hubURL = cdapConfig.get("market.base.url").getValue();
     URL pluginJsonURL = new URL(String.format("%s/packages/%s/%s/%s-%s.json",
-                                              caskMarketURL, packageName, version, pluginName, version));
+                                              hubURL, packageName, version, pluginName, version));
     // Avoid passing in an authentication token, which results in an auth failure when making requests to
     // the CDAP Hub. The CDAP Hub is available without any authentication.
     HttpResponse response = getRestClient().execute(HttpRequest.get(pluginJsonURL).build());
     Assert.assertEquals(200, response.getResponseCode());
 
     // get the artifact 'parents' from the plugin json
-    JsonObject pluginJson = new JsonParser().parse(response.getResponseBodyAsString()).getAsJsonObject();
-    JsonArray parents = pluginJson.get("parents").getAsJsonArray();
-    List<String> parentStrings = new ArrayList<>();
-    for (JsonElement parent : parents) {
-      parentStrings.add(parent.getAsString());
+    PluginAttributes pluginAttributes = GSON.fromJson(response.getResponseBodyAsString(), PluginAttributes.class);
+    List<String> parentStrings = pluginAttributes.getParents();
+    Set<ArtifactRange> parents = parentStrings.stream()
+      .map(p -> {
+        try {
+          return ArtifactRanges.parseArtifactRange(p);
+        } catch (InvalidArtifactRangeException e) {
+          throw new RuntimeException(e);
+        }
+      })
+      .collect(Collectors.toSet());
+
+    URL pluginJarURL = new URL(String.format("%s/packages/%s/%s/%s-%s.jar",
+                                             hubURL, packageName, version, pluginName, version));
+
+    try {
+      ArtifactId artifactId = TEST_NAMESPACE.artifact(pluginName, version);
+      artifactClient.add(artifactId, parents, pluginJarURL::openStream);
+    } catch (ArtifactAlreadyExistsException e) {
+      // ignore since it already exists
     }
-
-    // leverage a UI endpoint to upload the plugins from market
-    String source = URLEncoder.encode(
-      String.format("packages/%s/%s/%s-%s.jar",
-                    packageName, version, pluginName, version), "UTF-8");
-    String target = URLEncoder.encode(
-      String.format("v3/namespaces/%s/artifacts/%s", TEST_NAMESPACE.getNamespace(), pluginName), "UTF-8");
-
-    ConnectionConfig connConfig = getClientConfig().getConnectionConfig();
-    String uiPort = connConfig.isSSLEnabled() ?
-      cdapConfig.get("dashboard.ssl.bind.port").getValue() : cdapConfig.get("dashboard.bind.port").getValue();
-
-    // get sessionToken from UI
-    String url =
-            String.format("%s://%s:%s/sessionToken",
-                    connConfig.isSSLEnabled() ? "https" : "http",
-                    connConfig.getHostname(), // just assume that UI is colocated with Router
-                    uiPort);
-
-    response = getRestClient().execute(HttpMethod.GET, new URL(url), getClientConfig().getAccessToken());
-    Assert.assertEquals(200, response.getResponseCode());
-    String sessionToken = response.getResponseBodyAsString();
-
-    // use sessionToken and forward plugin from market to CDAP
-    url =
-      String.format("%s://%s:%s/forwardMarketToCdap?source=%s&target=%s",
-                    connConfig.isSSLEnabled() ? "https" : "http",
-                    connConfig.getHostname(), // just assume that UI is colocated with Router
-                    uiPort,
-                    source, target);
-
-    Map<String, String> headers =
-      ImmutableMap.of("Artifact-Extends", Joiner.on("/").join(parentStrings),
-                      "Artifact-Version", version,
-                      "session-token", sessionToken);
-    response = getRestClient().execute(HttpMethod.GET, new URL(url), headers, getClientConfig().getAccessToken());
-    Assert.assertEquals(200, response.getResponseCode());
   }
 
   protected void ingestData() throws Exception {

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/HivePluginTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/HivePluginTest.java
@@ -73,7 +73,7 @@ public class HivePluginTest extends ETLTestBase {
 
   @Test
   public void testHivePlugins() throws Exception {
-    installPluginFromMarket("hydrator-plugin-hive", "hive-plugins", "1.8.0-1.1.0");
+    installPluginFromHub("hydrator-plugin-hive", "hive-plugins", "1.8.0-1.1.0");
 
     ApplicationManager applicationManager = deployApplication(FileSetExample.class);
     ServiceManager fileSetService = applicationManager.getServiceManager("FileSetService").start();

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/hub/PluginAttributes.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/hub/PluginAttributes.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.hub;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Java representation of the plugin json config file.
+ */
+public class PluginAttributes {
+  private final List<String> parents;
+  private final Map<String, String> properties;
+
+  public PluginAttributes() {
+    this.parents = new ArrayList<>();
+    this.properties = new HashMap<>();
+  }
+
+  public List<String> getParents() {
+    return parents;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}


### PR DESCRIPTION
Fix the deploy hub plugin method to use the public CDAP REST APIs
instead of some UI endpoint that is subject to change and which is
currently broken.