### PR TITLE
make dataproc worker resources configurable

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -57,6 +57,8 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
   private static String projectId;
   private static String serviceAccountCredentials;
   private static String network;
+  private static int workerCPUs;
+  private static int workerMemMB;
   protected static final ArtifactSelectorConfig GOOGLE_CLOUD_ARTIFACT =
     new ArtifactSelectorConfig("SYSTEM", "google-cloud", "[0.0.0, 100.0.0)");
 
@@ -78,6 +80,8 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     projectId = serviceAccountJson.get("project_id").getAsString();
 
     network = System.getProperty("google.dataproc.network", "default");
+    workerCPUs = Integer.parseInt(System.getProperty("google.dataproc.worker.cpu", "4"));
+    workerMemMB = 1024 * Integer.parseInt(System.getProperty("google.dataproc.worker.mem.gb", "15"));
   }
 
   @Before
@@ -143,8 +147,8 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     properties.add(ofProperty("masterMemoryMB", "4096"));
     properties.add(ofProperty("masterDiskGB", "100"));
     properties.add(ofProperty("workerNumNodes", "2"));
-    properties.add(ofProperty("workerCPUs", "1"));
-    properties.add(ofProperty("workerMemoryMB", "4096"));
+    properties.add(ofProperty("workerCPUs", String.valueOf(workerCPUs)));
+    properties.add(ofProperty("workerMemoryMB", String.valueOf(workerMemMB)));
     properties.add(ofProperty("workerDiskGB", "100"));
 
     JsonObject provisioner = new JsonObject();


### PR DESCRIPTION
Add a way to modify the dataproc worker cpus and memory through
passing in system properties. Also set the default to a higher
value, since some pipelines seem to be stuck waiting for
resources.