### PR TITLE
CDAP-16454 increase time between status polls

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/KVTableWithProjectionTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/KVTableWithProjectionTest.java
@@ -35,10 +35,11 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Tests {@link KVTableSource} and {@link Properties.ProjectionTransform} convert function
+ * Tests {@link KVTableSource} and ProjectionTransform convert function
  */
 public class KVTableWithProjectionTest extends ETLTestBase {
 
@@ -67,7 +68,7 @@ public class KVTableWithProjectionTest extends ETLTestBase {
                                       new ETLPlugin("Projection", Transform.PLUGIN_TYPE,
                                                     ImmutableMap.of("convert", "ticker:bytes,price:bytes"),
                                                     null));
-    ETLBatchConfig etlBatchConfig = ETLBatchConfig.builder("*/10 * * * *")
+    ETLBatchConfig etlBatchConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addStage(transform)
@@ -79,8 +80,7 @@ public class KVTableWithProjectionTest extends ETLTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     byte[] result = getKVTableDataset(KVTABLE_NAME).get().read("AAPL");
     Assert.assertNotNull(result);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/TPFSAvroSinkSourceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/TPFSAvroSinkSourceTest.java
@@ -64,8 +64,7 @@ public class TPFSAvroSinkSourceTest extends ETLTestBase {
     // 1. Deploy an application with a service to get TPFS data for verification
     ApplicationManager applicationManager = deployApplication(DatasetAccessApp.class);
     ServiceManager serviceManager = applicationManager.getServiceManager(TPFSService.class.getSimpleName());
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
     // 2. Ingest data
     ingestData();
@@ -78,8 +77,8 @@ public class TPFSAvroSinkSourceTest extends ETLTestBase {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
 
     long timeInMillis = System.currentTimeMillis();
-    workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis)));
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED,
+                       ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis)), 10, TimeUnit.MINUTES);
 
     // 4. Run TPFS to TPFS pipeline where the source is the sink from the above pipeline
     ApplicationId tpfsToTPFSAppId = TEST_NAMESPACE.app("TPFSToTPFSWithProjection");
@@ -90,8 +89,8 @@ public class TPFSAvroSinkSourceTest extends ETLTestBase {
 
     // add 10 minutes to the end time to make sure the newly added partition is included in the run.
     long endRange = timeInMillis + 600 * 1000;
-    workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(endRange)));
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED,
+                       ImmutableMap.of("logical.start.time", String.valueOf(endRange)), 10, TimeUnit.MINUTES);
 
     // 5. Verify data in TPFS, add 10 minutes to the start of when the second pipeline runs to make sure the service
     //reads all partitions within the time range.

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/BatchAggregatorTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/BatchAggregatorTest.java
@@ -152,14 +152,12 @@ public class BatchAggregatorTest extends ETLTestBase {
     ApplicationManager applicationManager = deployApplication(DatasetAccessApp.class);
     ServiceManager serviceManager = applicationManager.getServiceManager(
       SnapshotFilesetService.class.getSimpleName());
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
     ingestData(PURCHASE_SOURCE);
 
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SMARTWORKFLOW_NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 15, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 15, TimeUnit.MINUTES);
 
     Map<String, List<Long>> groupedUsers = readOutput(serviceManager, USER_SINK);
     Map<String, List<Long>> groupedItems = readOutput(serviceManager, ITEM_SINK);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/BatchCubeSinkTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/BatchCubeSinkTest.java
@@ -104,8 +104,7 @@ public class BatchCubeSinkTest extends ETLTestBase {
     long startTs = System.currentTimeMillis() / 1000;
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     long endTs = System.currentTimeMillis() / 1000;
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/BatchJoinerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/BatchJoinerTest.java
@@ -212,14 +212,12 @@ public class BatchJoinerTest extends ETLTestBase {
 
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 15, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 15, TimeUnit.MINUTES);
 
     // Deploy an application with a service to get partitionedFileset data for verification
     ApplicationManager applicationManager = deployApplication(DatasetAccessApp.class);
     ServiceManager serviceManager = applicationManager.getServiceManager(SnapshotFilesetService.class.getSimpleName());
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
     org.apache.avro.Schema avroOutputSchema = new Parser().parse(outputSchema.toString());
     GenericRecord record1 = new GenericRecordBuilder(avroOutputSchema)

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ETLMapReduceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ETLMapReduceTest.java
@@ -102,8 +102,7 @@ public class ETLMapReduceTest extends ETLTestBase {
     table1.flush();
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<KeyValueTable> table2 = getKVTableDataset("table2");
     KeyValueTable outputTable = table2.get();
@@ -188,9 +187,8 @@ public class ETLMapReduceTest extends ETLTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
     ingestPurchaseTestData(getTableDataset("input"));
 
-    final WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     QueryClient client = new QueryClient(getClientConfig());
 
@@ -441,9 +439,8 @@ public class ETLMapReduceTest extends ETLTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
     ingestPurchaseTestData(getTableDataset("input"));
 
-    final WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     ExploreExecutionResult result = retryQueryExecutionTillFinished(TEST_NAMESPACE,
                                                                     "select * from dataset_allRewards", 5);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ExcelInputReaderTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ExcelInputReaderTest.java
@@ -65,8 +65,7 @@ public class ExcelInputReaderTest extends ETLTestBase {
     ApplicationManager applicationManager = deployApplication(UploadFile.class);
     String fileSetName = UploadFile.FileSetService.class.getSimpleName();
     ServiceManager serviceManager = applicationManager.getServiceManager(fileSetName);
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
     URL serviceURL = serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     URL url = new URL(serviceURL, "excelreader/create");
@@ -140,8 +139,7 @@ public class ExcelInputReaderTest extends ETLTestBase {
 
     // manually trigger the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(outputDatasetName);
     Table outputTable = outputManager.get();
@@ -210,8 +208,7 @@ public class ExcelInputReaderTest extends ETLTestBase {
 
     // manually trigger the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(outputDatasetName);
     Table outputTable = outputManager.get();

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/HivePluginTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/HivePluginTest.java
@@ -76,8 +76,8 @@ public class HivePluginTest extends ETLTestBase {
     installPluginFromHub("hydrator-plugin-hive", "hive-plugins", "1.8.0-1.1.0");
 
     ApplicationManager applicationManager = deployApplication(FileSetExample.class);
-    ServiceManager fileSetService = applicationManager.getServiceManager("FileSetService").start();
-    fileSetService.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    ServiceManager fileSetService = applicationManager.getServiceManager("FileSetService");
+    startAndWaitForRun(fileSetService, ProgramRunStatus.RUNNING);
     URL serviceURL = fileSetService.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     DatasetProperties datasetProperties = FileSetProperties.builder()
@@ -130,8 +130,8 @@ public class HivePluginTest extends ETLTestBase {
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(etlConfig);
     ApplicationId appId = TEST_NAMESPACE.app("HiveImportApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
-    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME).start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     // query the outputDataset to ensure that the data was written by the pipeline
     QueryClient queryClient = new QueryClient(getClientConfig());

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/NormalizeTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/NormalizeTest.java
@@ -127,8 +127,7 @@ public class NormalizeTest extends ETLTestBase {
   private void startWorkFlow(ApplicationManager appManager) throws TimeoutException, InterruptedException,
     ExecutionException {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
   }
 
   private void putData(int rowId, byte[] custId, byte[] itemId, byte[] itemCost, byte[] date, Table targetTable) {

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/RowDenormalizerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/RowDenormalizerTest.java
@@ -98,8 +98,7 @@ public class RowDenormalizerTest extends ETLTestBase {
     ApplicationManager appManager = deployApplication(appId, request);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(DENORMALIZER_SINK);
     Table outputTable = outputManager.get();

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/TPFSParquetSinkSourceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/TPFSParquetSinkSourceTest.java
@@ -73,8 +73,7 @@ public class TPFSParquetSinkSourceTest extends ETLTestBase {
     // 1. Deploy an application with a service to get TPFS data for verification
     ApplicationManager applicationManager = deployApplication(DatasetAccessApp.class);
     ServiceManager serviceManager = applicationManager.getServiceManager(TPFSService.class.getSimpleName());
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
     // 2. Ingest Data
     ingestData();
@@ -87,8 +86,9 @@ public class TPFSParquetSinkSourceTest extends ETLTestBase {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
 
     long timeInMillis = System.currentTimeMillis();
-    workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis)));
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED,
+                       ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis)),
+                       10, TimeUnit.MINUTES);
 
     // 4. Run TPFS to TPFS pipeline where the source is the sink from the above pipeline
     ApplicationId tpfsToTPFSAppId = TEST_NAMESPACE.app("TPFSToTPFSWithProjection");
@@ -99,8 +99,9 @@ public class TPFSParquetSinkSourceTest extends ETLTestBase {
 
     // add 10 minutes to the end time to make sure the newly added partition is included in the run.
     long endRange = timeInMillis + 600 * 1000;
-    workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(endRange)));
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED,
+                       ImmutableMap.of("logical.start.time", String.valueOf(endRange)),
+                       10, TimeUnit.MINUTES);
 
     // 5. Verify data in TPFS, add 10 minutes to the start of when the second pipeline runs to make sure the service
     //reads all partitions within the time range.

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ValueMapperTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ValueMapperTest.java
@@ -41,7 +41,6 @@ import io.cdap.plugin.common.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -103,7 +102,7 @@ public class ValueMapperTest extends ETLTestBase {
                                                 Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "name",
                                                 Properties.Table.PROPERTY_SCHEMA, SINK_SCHEMA.toString()), null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(transform)
       .addStage(sink)
@@ -134,14 +133,7 @@ public class ValueMapperTest extends ETLTestBase {
     inputManager.flush();
 
     WorkflowManager mrManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    mrManager.start();
-    mrManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
-
-    Map<String, String> nameDesignationMap = new HashMap<>();
-    nameDesignationMap.put("John", "DEFAULTID");
-    nameDesignationMap.put("Kerry", "SSE");
-    nameDesignationMap.put("Mathew", "DEFAULTID");
-    nameDesignationMap.put("Allie", "DEFAULTID");
+    startAndWaitForRun(mrManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> tableManager = getTableDataset(sinkTable);
     Table table = tableManager.get();

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/XMLParserTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/XMLParserTest.java
@@ -82,7 +82,7 @@ public class XMLParserTest extends ETLTestBase {
                                                               Properties.Table.PROPERTY_SCHEMA, SINK_SCHEMA.toString()),
                                               null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(transform)
       .addStage(sink)
@@ -109,16 +109,15 @@ public class XMLParserTest extends ETLTestBase {
     inputManager.flush();
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(xmlParserSink);
     Table outputTable = outputManager.get();
 
     Row row = outputTable.get(Bytes.toBytes("cooking"));
     Assert.assertEquals("Everyday Italian", row.getString("title"));
-    Assert.assertEquals(null, row.getString("price"));
-    Assert.assertEquals(null, row.getString("year"));
+    Assert.assertNull(row.getString("price"));
+    Assert.assertNull(row.getString("year"));
     Assert.assertEquals("<subcategory><type>Continental</type></subcategory>", row.getString("subcategory"));
 
     row = outputTable.get(Bytes.toBytes("children"));
@@ -169,7 +168,7 @@ public class XMLParserTest extends ETLTestBase {
                                                               Properties.Table.PROPERTY_SCHEMA, SINK_SCHEMA.toString()),
                                               null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(transform)
       .addStage(sink)
@@ -188,8 +187,7 @@ public class XMLParserTest extends ETLTestBase {
     inputManager.flush();
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(xmlParserSink);
     Table outputTable = outputManager.get();
@@ -226,7 +224,7 @@ public class XMLParserTest extends ETLTestBase {
                                                               Properties.Table.PROPERTY_SCHEMA, SINK_SCHEMA.toString()),
                                               null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(transform)
       .addStage(sink)
@@ -247,8 +245,7 @@ public class XMLParserTest extends ETLTestBase {
     inputManager.flush();
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(xmlParserSink);
     Table outputTable = outputManager.get();
@@ -285,7 +282,7 @@ public class XMLParserTest extends ETLTestBase {
                                                               Properties.Table.PROPERTY_SCHEMA, SINK_SCHEMA.toString()),
                                               null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(transform)
       .addStage(sink)
@@ -305,16 +302,15 @@ public class XMLParserTest extends ETLTestBase {
     inputManager.flush();
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getTableDataset(xmlParserSink);
     Table outputTable = outputManager.get();
 
     Row row = outputTable.get(Bytes.toBytes("cooking"));
     Assert.assertEquals("Everyday Italian", row.getString("title"));
-    Assert.assertEquals(null, row.getString("price"));
-    Assert.assertEquals(null, row.getString("year"));
+    Assert.assertNull(row.getString("price"));
+    Assert.assertNull(row.getString("year"));
     Assert.assertNull(row.getString("subcategory"));
   }
 
@@ -350,7 +346,7 @@ public class XMLParserTest extends ETLTestBase {
                                                 Properties.Table.PROPERTY_SCHEMA, SINK_SCHEMA.toString()),
                                               null));
 
-    ETLBatchConfig etlBatchConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlBatchConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addStage(transform)
@@ -373,8 +369,7 @@ public class XMLParserTest extends ETLTestBase {
     inputManager.flush();
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.KILLED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.KILLED, 10, TimeUnit.MINUTES);
     Assert.assertEquals(ProgramRunStatus.FAILED, workflowManager.getHistory().get(0).getStatus());
 
     DataSetManager<Table> outputManager = getTableDataset(xmlParserSink);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/XMLReaderTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/XMLReaderTest.java
@@ -80,8 +80,7 @@ public class XMLReaderTest extends ETLTestBase {
     ApplicationManager applicationManager = deployApplication(UploadFile.class);
     ServiceManager serviceManager = applicationManager.getServiceManager(UploadFile.
                                                                            FileSetService.class.getSimpleName());
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
     serviceURL = serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     URL url = new URL(serviceURL, "xmlreadersource/create");
@@ -147,8 +146,7 @@ public class XMLReaderTest extends ETLTestBase {
                              ProgramRunStatus expectedStatus) throws TimeoutException, InterruptedException,
     ExecutionException {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(expectedStatus, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, expectedStatus, 5, TimeUnit.MINUTES);
   }
 
   @Test

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -119,7 +119,7 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     Map<String, String> fullArgs = new HashMap<>();
     fullArgs.put("system.profile.name", getProfileName());
     fullArgs.putAll(args);
-    workflowManager.startAndWaitForRun(fullArgs, expectedStatus, 15, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, expectedStatus, fullArgs, 15, TimeUnit.MINUTES);
   }
 
   protected static String getServiceAccountCredentials() {

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/PubSubTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/PubSubTest.java
@@ -222,8 +222,8 @@ public class PubSubTest extends DataprocETLTestBase {
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     try {
       // it takes time to spin-up dataproc cluster, lets wait a little bit
-      sparkManager.startAndWaitForRun(Collections.singletonMap("system.profile.name", getProfileName()),
-                                      ProgramRunStatus.RUNNING, 10, TimeUnit.MINUTES);
+      startAndWaitForRun(sparkManager, ProgramRunStatus.RUNNING,
+                         Collections.singletonMap("system.profile.name", getProfileName()), 10, TimeUnit.MINUTES);
 
       // wait and check for source subscription to be created
       ensureSubscriptionCreated(pipelineReadSubscriptionName, 10, TimeUnit.MINUTES);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/realtime/DataStreamsTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/realtime/DataStreamsTest.java
@@ -72,8 +72,7 @@ public class DataStreamsTest extends ETLTestBase {
     ApplicationManager applicationManager = deployApplication(UploadFile.class);
     String fileSetName = UploadFile.FileSetService.class.getSimpleName();
     ServiceManager serviceManager = applicationManager.getServiceManager(fileSetName);
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
     URL serviceURL = serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     URL url = new URL(serviceURL, "testFileSet/create");
@@ -127,8 +126,7 @@ public class DataStreamsTest extends ETLTestBase {
     AppRequest appRequest = getStreamingAppRequest(config);
     ApplicationManager appManager = deployApplication(appId, appRequest);
     SparkManager sparkManager = appManager.getSparkManager("DataStreamsSparkStreaming");
-    sparkManager.start();
-    sparkManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(sparkManager, ProgramRunStatus.RUNNING);
 
     url = new URL(serviceURL, "testFileSet?path=test1.csv");
     //PUT request to upload the test1.csv file, sent in the request body
@@ -147,7 +145,8 @@ public class DataStreamsTest extends ETLTestBase {
     verifyOutput(table, "2", "Marshall", "Mathers");
 
     sparkManager.stop();
-    sparkManager.waitForRun(ProgramRunStatus.KILLED, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    sparkManager.waitForRuns(ProgramRunStatus.KILLED, 1, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                             POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
   }
 
   private void verifyOutput(final Table table, final String id, String firstName, String lastName)

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/wrangler/WranglerServiceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/wrangler/WranglerServiceTest.java
@@ -139,9 +139,8 @@ public class WranglerServiceTest extends ETLTestBase {
 
     ServiceManager serviceManager = appManager.getServiceManager("service");
     if (!serviceManager.isRunning()) {
-      serviceManager.start();
+      startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
     }
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 5, TimeUnit.MINUTES);
     return serviceManager;
   }
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/wrangler/WranglerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/wrangler/WranglerTest.java
@@ -162,8 +162,7 @@ public class WranglerTest extends ETLTestBase {
 
     // run the pipeline
     WorkflowManager workflowManager = testAppManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 10, TimeUnit.MINUTES);
 
     // Deploy an application with a service to get partitionedFileset data for verification
     ApplicationManager appManager = deployApplication(DatasetAccessApp.class);
@@ -199,8 +198,7 @@ public class WranglerTest extends ETLTestBase {
   private ServiceManager startService(ApplicationManager appManager, String service) throws InterruptedException,
     ExecutionException, TimeoutException {
     ServiceManager serviceManager = appManager.getServiceManager(service);
-    serviceManager.start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
     return serviceManager;
   }
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/mapreduce/readless/ReadlessIncrementTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/mapreduce/readless/ReadlessIncrementTest.java
@@ -60,13 +60,11 @@ public class ReadlessIncrementTest extends AudiTestBase {
     ApplicationManager appManager = deployApplication(ReadlessApp.class);
 
     ServiceManager serviceManager = appManager.getServiceManager(ReadlessApp.SERVICE_NAME);
-    serviceManager.start();
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
     MapReduceManager mapReduceManager = appManager.getMapReduceManager(ReadlessApp.MAPREDUCE_NAME);
-    mapReduceManager.start();
-    mapReduceManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(mapReduceManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 5, TimeUnit.SECONDS);
     URL url = new URL(serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS), "get");
     HttpResponse response = getRestClient().execute(HttpRequest.get(url).build(), getClientConfig().getAccessToken(),
                                                     HttpURLConnection.HTTP_OK);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/restart/HangingWorkerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/restart/HangingWorkerTest.java
@@ -48,8 +48,8 @@ public class HangingWorkerTest extends AudiTestBase {
     ApplicationManager applicationManager = deployApplication(HangingWorkerApp.class);
 
     // start the worker
-    WorkerManager workerManager = applicationManager.getWorkerManager(HangingWorkerApp.WORKER_NAME).start();
-    workerManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    WorkerManager workerManager = applicationManager.getWorkerManager(HangingWorkerApp.WORKER_NAME);
+    startAndWaitForRun(workerManager, ProgramRunStatus.RUNNING);
 
     // the worker writes current time into workerDataset every HangingWorkerApp.WORKER_SLEEP_SECS secs
     final DataSetManager<KeyValueTable> workerDataset = getKVTableDataset(HangingWorkerApp.WORKER_DATASET_NAME);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/serviceworker/ServiceWorkerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/serviceworker/ServiceWorkerTest.java
@@ -65,8 +65,8 @@ public class ServiceWorkerTest extends AudiTestBase {
     RESTClient restClient = getRestClient();
     ApplicationManager applicationManager = deployApplication(ServiceApplication.class);
 
-    ServiceManager serviceManager = applicationManager.getServiceManager(ServiceApplication.SERVICE_NAME).start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    ServiceManager serviceManager = applicationManager.getServiceManager(ServiceApplication.SERVICE_NAME);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
 
     URL serviceURL = serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -77,9 +77,9 @@ public class ServiceWorkerTest extends AudiTestBase {
     Assert.assertEquals(HttpURLConnection.HTTP_NO_CONTENT, response.getResponseCode());
 
     // start the worker
-    WorkerManager workerManager = applicationManager.getWorkerManager(ServiceApplication.WORKER_NAME).start();
+    WorkerManager workerManager = applicationManager.getWorkerManager(ServiceApplication.WORKER_NAME);
     // worker will stop automatically
-    workerManager.waitForRun(ProgramRunStatus.COMPLETED, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(workerManager, ProgramRunStatus.COMPLETED);
 
     // check if the worker's write to the table was successful
     response = restClient.execute(HttpRequest.get(url).build(), getClientConfig().getAccessToken());
@@ -98,7 +98,8 @@ public class ServiceWorkerTest extends AudiTestBase {
     }
 
     serviceManager.stop();
-    serviceManager.waitForRun(ProgramRunStatus.KILLED, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    serviceManager.waitForRuns(ProgramRunStatus.KILLED, 1, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                               POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
 
     // Now testing the artifact listing / class loading using the Artifact HTTP Service
     final File directiveJar =
@@ -118,8 +119,8 @@ public class ServiceWorkerTest extends AudiTestBase {
                                          new ArtifactVersion("10.0.0-SNAPSHOT")));
     artifactClient.add(artifactId, parentArtifacts, () -> new FileInputStream(directiveJar));
 
-    serviceManager = applicationManager.getServiceManager(ServiceApplication.ARTIFACT_SERVICE_NAME).start();
-    serviceManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    serviceManager = applicationManager.getServiceManager(ServiceApplication.ARTIFACT_SERVICE_NAME);
+    startAndWaitForRun(serviceManager, ProgramRunStatus.RUNNING);
 
 
     serviceURL = serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -136,6 +137,7 @@ public class ServiceWorkerTest extends AudiTestBase {
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
 
     serviceManager.stop();
-    serviceManager.waitForRun(ProgramRunStatus.KILLED, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    serviceManager.waitForRuns(ProgramRunStatus.KILLED, 1, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                               POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
   }
 }

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/ApplicationTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/ApplicationTest.java
@@ -38,8 +38,8 @@ public class ApplicationTest extends AudiTestBase {
   @Test
   public void test() throws Exception {
     ApplicationManager applicationManager = deployApplication(FileSetExample.class);
-    ServiceManager fileSetService = applicationManager.getServiceManager(FileSetService.class.getSimpleName()).start();
-    fileSetService.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    ServiceManager fileSetService = applicationManager.getServiceManager(FileSetService.class.getSimpleName());
+    startAndWaitForRun(fileSetService, ProgramRunStatus.RUNNING);
 
     // should not delete application when programs are running
     ApplicationClient appClient = new ApplicationClient(getClientConfig(), getRestClient());

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/dataset/DatasetTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/dataset/DatasetTest.java
@@ -94,8 +94,8 @@ public class DatasetTest extends AudiTestBase {
     datasetClient.delete(testDatasetinstance);
     Assert.assertEquals(appDatasetsCount, datasetClient.list(TEST_NAMESPACE).size());
 
-    ServiceManager wordCountService = applicationManager.getServiceManager(RetrieveCounts.SERVICE_NAME).start();
-    wordCountService.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    ServiceManager wordCountService = applicationManager.getServiceManager(RetrieveCounts.SERVICE_NAME);
+    startAndWaitForRun(wordCountService, ProgramRunStatus.RUNNING);
 
     ingestData();
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionedFileSetUpdateTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionedFileSetUpdateTest.java
@@ -59,8 +59,8 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
   public void test() throws Exception {
     ApplicationManager applicationManager = deployApplication(PFSApp.class);
 
-    ServiceManager pfsService = applicationManager.getServiceManager("PFSService").start();
-    pfsService.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    ServiceManager pfsService = applicationManager.getServiceManager("PFSService");
+    startAndWaitForRun(pfsService, ProgramRunStatus.RUNNING);
     URL serviceURL = pfsService.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     HttpResponse response = getRestClient().execute(HttpRequest.put(new URL(serviceURL, "1")).build(),
@@ -107,9 +107,8 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
     validate(client, "i", "j", 3, 4);
 
     // run the partition corrector. This should bring all partitions to use delimiter :
-    WorkerManager pfsWorker = applicationManager
-      .getWorkerManager("PartitionWorker").start(ImmutableMap.of("dataset.name", "pfs"));
-    pfsWorker.waitForRun(ProgramRunStatus.COMPLETED, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    WorkerManager pfsWorker = applicationManager.getWorkerManager("PartitionWorker");
+    startAndWaitForRun(pfsWorker, ProgramRunStatus.COMPLETED, ImmutableMap.of("dataset.name", "pfs"));
 
     validate(client, "i", "j", 0, 4);
   }

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/metadata/ProgramMetadataStressTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/metadata/ProgramMetadataStressTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.test.AudiTestBase;
 import io.cdap.cdap.test.MapReduceManager;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -40,7 +41,6 @@ public class ProgramMetadataStressTest extends AudiTestBase {
     ApplicationManager applicationManager = deployApplication(ProgramMetadataStressApp.class);
     MapReduceManager mapReduceManager =
       applicationManager.getMapReduceManager(PROGRAM.getProgram());
-    mapReduceManager.start();
-    mapReduceManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(mapReduceManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
   }
 }

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/metadata/ProgramMetadataTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/metadata/ProgramMetadataTest.java
@@ -92,8 +92,7 @@ public class ProgramMetadataTest extends AudiTestBase {
 
     MapReduceManager mapReduceManager =
       applicationManager.getMapReduceManager(PROGRAM.getProgram());
-    mapReduceManager.start();
-    mapReduceManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(mapReduceManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     List<RunRecord> runRecords = getRunRecords(1, programClient, PROGRAM,
                                                ProgramRunStatus.COMPLETED.name(), 0, endTime);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/workflow/WorkflowTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/workflow/WorkflowTest.java
@@ -37,9 +37,7 @@ public class WorkflowTest extends AudiTestBase {
     WorkflowManager workflowManager =
       applicationManager.getWorkflowManager(WorkflowAppWithFork.WorkflowWithFork.class.getSimpleName());
 
-    workflowManager.start();
-
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     Assert.assertEquals(
       Long.valueOf(

--- a/integration-test-remote/src/test/java/io/cdap/cdap/security/AppImpersonationTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/security/AppImpersonationTest.java
@@ -106,19 +106,15 @@ public class AppImpersonationTest extends AudiTestBase {
     Assert.assertEquals(QueryStatus.OpStatus.FINISHED, results.getStatus().getStatus());
     Assert.assertFalse(results.hasNext());
 
-    generatorWorkerManager.start();
-    generatorWorkerManager.waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    startAndWaitForRun(generatorWorkerManager, ProgramRunStatus.RUNNING);
 
     TimeUnit.SECONDS.sleep(15);
 
     generatorWorkerManager.stop();
-    generatorWorkerManager.waitForRun(ProgramRunStatus.KILLED, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    generatorWorkerManager.waitForRuns(ProgramRunStatus.KILLED, 1, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                                       POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
 
-    processorWorkflowManager.start();
-    processorWorkflowManager
-      .waitForRun(ProgramRunStatus.RUNNING, PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-    processorWorkflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    startAndWaitForRun(processorWorkflowManager, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     // Ensure that there is at least one result
     results = new QueryClient(getClientConfig())


### PR DESCRIPTION
Increase the time between program status polls, since most programs
take minutes to run and don't need to be polled every 50 milliseconds.
This also greatly reduces the amount of logging, making it
easier to investigate failures.