### PR TITLE
fix integration tests

### DIFF
--- a/integration-test-remote/pom.xml
+++ b/integration-test-remote/pom.xml
@@ -90,18 +90,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!--TODO: remove gax-grpc once cloud-dlp API is compatible with latest version -->
-    <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax-grpc</artifactId>
-      <version>1.54.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-dlp</artifactId>
-      <version>1.0.1</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleBigQueryTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleBigQueryTest.java
@@ -1092,17 +1092,17 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
 
     Map<String, String> sourceProps = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "bigQuery_source")
-      .put("project", getProjectId())
-      .put("dataset", bigQueryDataset)
-      .put("table", sourceTableName)
-      .put("schema", sourceSchema.toString())
+      .put("project", "${project}")
+      .put("dataset", "${dataset}")
+      .put("table", "${srcTable}")
+      .put("schema", "${srcSchema}")
       .build();
 
     Map<String, String> sinkProps = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "bigQuery_sink")
-      .put("project", getProjectId())
-      .put("dataset", bigQueryDataset)
-      .put("table", destinationTableName)
+      .put("project", "${project}")
+      .put("dataset", "${dataset}")
+      .put("table", "${dstTable}")
       .put("operation", "UPDATE")
       .put("relationTableKey", "string_value")
       .put("dedupeBy", "int_value ASC")
@@ -1111,9 +1111,16 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
 
     int expectedCount = 2;
 
+    Map<String, String> runtimeArgs = new HashMap<>();
+    runtimeArgs.put("project", getProjectId());
+    runtimeArgs.put("dataset", bigQueryDataset);
+    runtimeArgs.put("srcTable", sourceTableName);
+    runtimeArgs.put("srcSchema", sourceSchema.toString());
+    runtimeArgs.put("dstTable", destinationTableName);
+
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
       deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-updateWithDedupeSourceData");
-    startWorkFlow(deploymentDetails.getAppManager(), ProgramRunStatus.COMPLETED);
+    startWorkFlow(deploymentDetails.getAppManager(), ProgramRunStatus.COMPLETED, runtimeArgs);
 
     ApplicationId appId = deploymentDetails.getAppId();
     Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespace(),
@@ -1177,17 +1184,17 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
 
     Map<String, String> sourceProps = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "bigQuery_source")
-      .put("project", getProjectId())
-      .put("dataset", bigQueryDataset)
-      .put("table", sourceTableName)
-      .put("schema", sourceSchema.toString())
+      .put("project", "${project}")
+      .put("dataset", "${dataset}")
+      .put("table", "${srcTable}")
+      .put("schema", "${srcSchema}")
       .build();
 
     Map<String, String> sinkProps = new ImmutableMap.Builder<String, String>()
       .put("referenceName", "bigQuery_sink")
-      .put("project", getProjectId())
-      .put("dataset", bigQueryDataset)
-      .put("table", destinationTableName)
+      .put("project", "${project}")
+      .put("dataset", "${dataset}")
+      .put("table", "${dstTable}")
       .put("operation", "UPSERT")
       .put("relationTableKey", "string_value")
       .put("dedupeBy", "float_value DESC")
@@ -1196,9 +1203,16 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
 
     int expectedCount = 3;
 
+    Map<String, String> runtimeArgs = new HashMap<>();
+    runtimeArgs.put("project", getProjectId());
+    runtimeArgs.put("dataset", bigQueryDataset);
+    runtimeArgs.put("srcTable", sourceTableName);
+    runtimeArgs.put("srcSchema", sourceSchema.toString());
+    runtimeArgs.put("dstTable", destinationTableName);
+
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
       deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-upsertWithDedupeSourceData");
-    startWorkFlow(deploymentDetails.getAppManager(), ProgramRunStatus.COMPLETED);
+    startWorkFlow(deploymentDetails.getAppManager(), ProgramRunStatus.COMPLETED, runtimeArgs);
 
     ApplicationId appId = deploymentDetails.getAppId();
     Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespace(),

--- a/integration-test-remote/src/test/java/io/cdap/cdap/test/suite/GCPSuite.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/test/suite/GCPSuite.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.test.suite;
 
+import io.cdap.cdap.app.etl.gcp.DLPTest;
 import io.cdap.cdap.app.etl.gcp.GCSTest;
 import io.cdap.cdap.app.etl.gcp.GoogleBigQueryTest;
 import io.cdap.cdap.app.etl.gcp.GoogleCloudBigtableTest;
@@ -35,7 +36,8 @@ import org.junit.runners.Suite;
   GoogleCloudBigtableTest.class,
   GoogleCloudDatastoreTest.class,
   GoogleCloudSpannerTest.class,
-  PubSubTest.class
+  PubSubTest.class,
+  DLPTest.class
 })
 public class GCPSuite {
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,17 +60,17 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.36.0</version>
+      <version>1.103.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>1.36.0</version>
+      <version>1.105.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>1.61.0</version>
+      <version>1.101.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>0.53.0-beta</version>
+      <version>1.49.2</version>
       <exclusions>
         <exclusion>
           <groupId>io.opencensus</groupId>
@@ -97,7 +97,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>1.36.0</version>
+      <version>1.107.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-dlp</artifactId>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Fix the google library dependencies to versions that all use
compatible dependencies, and remove the direct gax-grpc depdendency
that was causing Spanner to fail.

Also use macros in the BQ tests to both test macros and to
workaround an issue when the CDAP instance is running on a GCE
VM.