### PR TITLE
Bump version and fix spanner

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
@@ -370,8 +370,8 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
   private void checkMetrics(String applicationName, int expectedCount) throws Exception {
     Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, TEST_NAMESPACE.getNamespace(),
                                                Constants.Metrics.Tag.APP, applicationName);
-    checkMetric(tags, "user." + SPANNER_SOURCE_STAGE_NAME + ".records.out", expectedCount, 10);
-    checkMetric(tags, "user." + SPANNER_SINK_STAGE_NAME + ".records.in", expectedCount, 10);
+    checkMetric(tags, "user." + SPANNER_SOURCE_STAGE_NAME + ".records.out", expectedCount, 60);
+    checkMetric(tags, "user." + SPANNER_SINK_STAGE_NAME + ".records.in", expectedCount, 60);
   }
 
   private void verifySinkData(String tableName) {

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <bigtable.version>1.8.0</bigtable.version>
-    <cdap.pre.version>6.2.1</cdap.pre.version>
-    <cdap.version>6.3.0-SNAPSHOT</cdap.version>
-    <cdap.plugin.version>2.5.0-SNAPSHOT</cdap.plugin.version>
+    <cdap.pre.version>6.2.3</cdap.pre.version>
+    <cdap.version>6.4.0-SNAPSHOT</cdap.version>
+    <cdap.plugin.version>2.6.0-SNAPSHOT</cdap.plugin.version>
     <!-- cdap.examples.version is overridden in the pre-stage of upgrade tests -->
     <cdap.examples.version>${cdap.version}</cdap.examples.version>
     <cdap.common.version>0.13.0-SNAPSHOT</cdap.common.version>


### PR DESCRIPTION
In some slow instance and network, seeing the metrics doesn't get published within the original timeout, so increasing the timeout of it. 