### PR TITLE
Cdap 17543 fix cloud itn

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DLPTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DLPTest.java
@@ -235,7 +235,7 @@ public class DLPTest extends DataprocETLTestBase {
         .put("serviceFilePath", "auto-detect")
         .put("location", "us")
         .put("referenceName", "sink-emails-with-redaction")
-        .put("path", createPath(bucket, "test-output")).build(), GOOGLE_CLOUD_ARTIFACT));
+        .put("path", createPath(bucket, "test-output-" + engine)).build(), GOOGLE_CLOUD_ARTIFACT));
 
     ETLBatchConfig config = ETLBatchConfig.builder()
       .addStage(gcsSourceStage)
@@ -247,13 +247,13 @@ public class DLPTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("DLPRedactTest");
+    ApplicationId appId = TEST_NAMESPACE.app("DLPRedactTest" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // start the pipeline and wait for it to finish
     startWorkFlow(appManager, ProgramRunStatus.COMPLETED);
 
-    assertGCSContentsMatch(bucket, "test-output/",
+    assertGCSContentsMatch(bucket, "test-output-" + engine + "/",
       Sets.newHashSet(
         "0,alice,#################",
         "1,bob,###############",
@@ -283,7 +283,7 @@ public class DLPTest extends DataprocETLTestBase {
         .put("serviceFilePath", "auto-detect")
         .put("location", "us")
         .put("referenceName", "sink-emails-with-filter")
-        .put("path", createPath(bucket, "test-output-sensitive")).build(), GOOGLE_CLOUD_ARTIFACT));
+        .put("path", createPath(bucket, "test-output-sensitive-" + engine)).build(), GOOGLE_CLOUD_ARTIFACT));
 
     ETLStage sinkStage2 =
       new ETLStage("copy of GCS2", new ETLPlugin("GCS", BatchSink.PLUGIN_TYPE,
@@ -293,7 +293,7 @@ public class DLPTest extends DataprocETLTestBase {
           .put("serviceFilePath", "auto-detect")
           .put("location", "us")
           .put("referenceName", "sink-emails-with-filter")
-          .put("path", createPath(bucket, "test-output-nonsensitive")).build(), GOOGLE_CLOUD_ARTIFACT));
+          .put("path", createPath(bucket, "test-output-nonsensitive-" + engine)).build(), GOOGLE_CLOUD_ARTIFACT));
 
     ETLBatchConfig config = ETLBatchConfig.builder()
       .addStage(gcsSourceStage)
@@ -307,17 +307,17 @@ public class DLPTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("DLPFilterTest");
+    ApplicationId appId = TEST_NAMESPACE.app("DLPFilterTest" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // start the pipeline and wait for it to finish
     startWorkFlow(appManager, ProgramRunStatus.COMPLETED);
 
-    assertGCSContentsMatch(bucket, "test-output-sensitive/",
+    assertGCSContentsMatch(bucket, "test-output-sensitive-" + engine + "/",
       Sets.newHashSet(
         "0,alice,alice@example.com",
         "1,bob,bob@example.com",
         "2,craig,craig@example.com"));
-    assertGCSContentsMatch(bucket, "test-output-nonsensitive/", Sets.newHashSet());
+    assertGCSContentsMatch(bucket, "test-output-nonsensitive-" + engine + "/", Sets.newHashSet());
   }
 }

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GCSTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GCSTest.java
@@ -302,7 +302,7 @@ public class GCSTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("GCSCopyTest");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSCopyTest" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // start the pipeline and wait for it to finish
@@ -387,7 +387,7 @@ public class GCSTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("GCSMoveTest");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSMoveTest" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // start the pipeline and wait for it to finish
@@ -434,7 +434,7 @@ public class GCSTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("GCSMoveTestRecursive");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSMoveTestRecursive" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // start the pipeline and wait for it to finish
@@ -472,7 +472,7 @@ public class GCSTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("GCSCreateTest");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSCreateTest" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // mark possibly created in future bucket for deletion
@@ -518,7 +518,7 @@ public class GCSTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(config);
-    ApplicationId appId = TEST_NAMESPACE.app("GCSDeleteTest");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSDeleteTest" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // start the pipeline and wait for it to finish
@@ -575,8 +575,8 @@ public class GCSTest extends DataprocETLTestBase {
   private void testAllTypes(Engine engine) throws Exception {
     String bucketName = "co-cask-test-bucket-" + System.currentTimeMillis();
     Bucket bucket = createBucket(bucketName);
-    String inputBlobName = "gcs-types/test.avro";
-    String outputBlobName = "output/gcs-types/json";
+    String inputBlobName = "gcs-types/" + engine + "/test.avro";
+    String outputBlobName = "output/" + engine + "/gcs-types/json";
 
     String schema = ALL_DT_SCHEMA.toString();
 
@@ -676,7 +676,7 @@ public class GCSTest extends DataprocETLTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(etlConfig);
-    ApplicationId appId = TEST_NAMESPACE.app("GCSToGCS");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSToGCS" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     startWorkFlow(appManager, ProgramRunStatus.COMPLETED);
@@ -785,7 +785,7 @@ public class GCSTest extends DataprocETLTestBase {
     pipelineConfig.setEngine(engine);
 
     AppRequest<ETLBatchConfig> appRequest = getBatchAppRequestV2(pipelineConfig.build());
-    ApplicationId appId = TEST_NAMESPACE.app("GCSFormatSinks");
+    ApplicationId appId = TEST_NAMESPACE.app("GCSFormatSinks" + engine);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     startWorkFlow(appManager, ProgramRunStatus.COMPLETED);
@@ -816,7 +816,7 @@ public class GCSTest extends DataprocETLTestBase {
     pipelineConfig.setEngine(engine);
 
     appRequest = getBatchAppRequestV2(pipelineConfig.build());
-    appId = TEST_NAMESPACE.app("GCSFormatSources");
+    appId = TEST_NAMESPACE.app("GCSFormatSources" + engine);
     appManager = deployApplication(appId, appRequest);
     startWorkFlow(appManager, ProgramRunStatus.COMPLETED);
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleBigQueryTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleBigQueryTest.java
@@ -233,7 +233,7 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 1;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-storeInNewTable", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine + "-storeInNewTable", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -314,7 +314,7 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 1;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-storeInExistingTable", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine + "-storeInExistingTable", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -413,7 +413,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 1;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-storeWithUpdateTableSchema", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME +
+                                                  engine + "-storeWithUpdateTableSchema", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -516,7 +517,7 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 1;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-allBigQueryTypes", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine +  "-allBigQueryTypes", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -596,7 +597,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 3;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-updateWithoutSchemaUpdate", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME +
+                                                  engine + "-updateWithoutSchemaUpdate", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -694,7 +696,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 3;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-upsertWithoutSchemaUpdate", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine +
+                                                  "-upsertWithoutSchemaUpdate", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -806,7 +809,7 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 3;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-insertWithSchemaUpdate", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine + "-insertWithSchemaUpdate", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -925,7 +928,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 3;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-updateWithSchemaUpdate", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine +
+                                                  "-updateWithSchemaUpdate", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -1023,7 +1027,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     int expectedCount = 3;
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-upsertWithSchemaUpdate", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine +
+                                                  "-upsertWithSchemaUpdate", engine);
     Map<String, String> args = new HashMap<>();
     args.put("project", getProjectId());
     args.put("dataset", bigQueryDataset);
@@ -1141,7 +1146,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     runtimeArgs.put("dstTable", destinationTableName);
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-updateWithDedupeSourceData", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine +
+                                                  "-updateWithDedupeSourceData", engine);
     startWorkFlow(deploymentDetails.getAppManager(), ProgramRunStatus.COMPLETED, runtimeArgs);
 
     ApplicationId appId = deploymentDetails.getAppId();
@@ -1238,7 +1244,8 @@ public class GoogleBigQueryTest extends DataprocETLTestBase {
     runtimeArgs.put("dstTable", destinationTableName);
 
     GoogleBigQueryTest.DeploymentDetails deploymentDetails =
-      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + "-upsertWithDedupeSourceData", engine);
+      deployApplication(sourceProps, sinkProps, BIG_QUERY_PLUGIN_NAME + engine +
+                                                  "-upsertWithDedupeSourceData", engine);
     startWorkFlow(deploymentDetails.getAppManager(), ProgramRunStatus.COMPLETED, runtimeArgs);
 
     ApplicationId appId = deploymentDetails.getAppId();

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
@@ -244,7 +244,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
       .put("keys", "${keys}")
       .build();
 
-    String applicationName = SPANNER_PLUGIN_NAME + "-testReadAndStoreInNewTable";
+    String applicationName = SPANNER_PLUGIN_NAME + engine + "-testReadAndStoreInNewTable";
     ApplicationManager applicationManager = deployApplication(sourceProperties, sinkProperties,
                                                               applicationName, engine);
     Map<String, String> args = new HashMap<>();
@@ -285,7 +285,8 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
       .put("schema", SCHEMA.toString())
       .build();
 
-    String applicationName = SPANNER_PLUGIN_NAME + "-testReadAndStore";
+    String sinkTable = SINK_TABLE_NAME + engine;
+    String applicationName = SPANNER_PLUGIN_NAME + engine + "-testReadAndStore";
     ApplicationManager applicationManager = deployApplication(sourceProperties, sinkProperties,
                                                               applicationName, engine);
     Map<String, String> args = new HashMap<>();
@@ -293,7 +294,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
     args.put("instance", instance.getId().getInstance());
     args.put("database", database.getId().getDatabase());
     args.put("srcTable", SOURCE_TABLE_NAME);
-    args.put("dstTable", SINK_TABLE_NAME);
+    args.put("dstTable", sinkTable);
     args.put("keys", "ID");
     startWorkFlow(applicationManager, ProgramRunStatus.COMPLETED, args);
 
@@ -301,7 +302,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
 
     ResultSet resultSet = spanner.getDatabaseClient(database.getId())
       .singleUse()
-      .executeQuery(Statement.of(String.format("select * from %s;", SINK_TABLE_NAME)));
+      .executeQuery(Statement.of(String.format("select * from %s;", sinkTable)));
     verifySinkData(resultSet);
     Assert.assertTrue(resultSet.isNull("NOT_IN_THE_SCHEMA_COL"));
   }
@@ -333,7 +334,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
       .put("keys", "${keys}")
       .build();
 
-    String applicationName = SPANNER_PLUGIN_NAME + "-testReadAndStoreInNewTableWithNoSourceSchema";
+    String applicationName = SPANNER_PLUGIN_NAME + engine + "-testReadAndStoreInNewTableWithNoSourceSchema";
     ApplicationManager applicationManager = deployApplication(sourceProperties, sinkProperties,
                                                               applicationName, engine);
     Map<String, String> args = new HashMap<>();
@@ -373,6 +374,7 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
       .put("schema", SCHEMA.toString())
       .build();
 
+    String sinkTable = SINK_TABLE_NAME + engine;
     String applicationName = SPANNER_PLUGIN_NAME + "-testReadAndStoreWithNoSourceSchema";
     ApplicationManager applicationManager = deployApplication(sourceProperties, sinkProperties,
                                                               applicationName, engine);
@@ -381,14 +383,14 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
     args.put("instance", instance.getId().getInstance());
     args.put("database", database.getId().getDatabase());
     args.put("srcTable", SOURCE_TABLE_NAME);
-    args.put("dstTable", SINK_TABLE_NAME);
+    args.put("dstTable", sinkTable);
     startWorkFlow(applicationManager, ProgramRunStatus.COMPLETED, args);
 
     checkMetrics(applicationName, SOURCE_TABLE_TEST_MUTATIONS.size());
 
     ResultSet resultSet = spanner.getDatabaseClient(database.getId())
       .singleUse()
-      .executeQuery(Statement.of(String.format("select * from %s;", SINK_TABLE_NAME)));
+      .executeQuery(Statement.of(String.format("select * from %s;", sinkTable)));
     verifySinkData(resultSet);
     Assert.assertTrue(resultSet.isNull("NOT_IN_THE_SCHEMA_COL"));
   }
@@ -464,7 +466,8 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
     Database database = spanner.getDatabaseAdminClient()
       .createDatabase(instance.getId().getInstance(), databaseName, ImmutableList.of(
         String.format(TABLE_FORMAT, SOURCE_TABLE_NAME),
-        String.format(TABLE_FORMAT, SINK_TABLE_NAME)))
+        String.format(TABLE_FORMAT, SINK_TABLE_NAME + Engine.MAPREDUCE),
+        String.format(TABLE_FORMAT, SINK_TABLE_NAME + Engine.SPARK)))
       .get();
     LOG.info("Created instance {}", databaseName);
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GoogleCloudSpannerTest.java
@@ -396,8 +396,8 @@ public class GoogleCloudSpannerTest extends DataprocETLTestBase {
   private void checkMetrics(String applicationName, int expectedCount) throws Exception {
     Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, TEST_NAMESPACE.getNamespace(),
                                                Constants.Metrics.Tag.APP, applicationName);
-    checkMetric(tags, "user." + SPANNER_SOURCE_STAGE_NAME + ".records.out", expectedCount, 10);
-    checkMetric(tags, "user." + SPANNER_SINK_STAGE_NAME + ".records.in", expectedCount, 10);
+    checkMetric(tags, "user." + SPANNER_SOURCE_STAGE_NAME + ".records.out", expectedCount, 60);
+    checkMetric(tags, "user." + SPANNER_SINK_STAGE_NAME + ".records.in", expectedCount, 60);
   }
 
   private void verifySinkData(String tableName) {


### PR DESCRIPTION
The cloud itn is failing since we recently made a change to run the pipeline with both mapreduce and spark engines, this made the test fail because the pipeline checks for metrics, update schema of the table in the run. So second run will fail with metrics check failure or program run failure or app deploy failure. 

Have run at least one test from each class on sandbox to make sure the changes are working.