### PR TITLE
Update tests to be compatible with new ITN system

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ExcelInputReaderTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ExcelInputReaderTest.java
@@ -70,7 +70,8 @@ public class ExcelInputReaderTest extends ETLTestBase {
 
     URL url = new URL(serviceURL, "excelreader/create");
     //POST request to create a new file set with name excelreadersource.
-    HttpResponse response = getRestClient().execute(HttpMethod.POST, url, getClientConfig().getAccessToken());
+    HttpResponse response = getRestClient()
+      .execute(HttpRequest.post(url).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
 
     url = new URL(serviceURL, "excelreader?path=civil_test_data_one.xlsx");
@@ -184,9 +185,9 @@ public class ExcelInputReaderTest extends ETLTestBase {
     String outputDatasetName = "output-batchsourcetest-testexcelreaderreprocessfalse";
 
     ETLStage sink = new ETLStage("TableSink", new ETLPlugin("Table", BatchSink.PLUGIN_TYPE, ImmutableMap.of(
-                                                Properties.BatchReadableWritable.NAME, outputDatasetName,
-                                                Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "A",
-                                                Properties.Table.PROPERTY_SCHEMA, schema.toString()), null));
+      Properties.BatchReadableWritable.NAME, outputDatasetName,
+      Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "A",
+      Properties.Table.PROPERTY_SCHEMA, schema.toString()), null));
 
     ETLBatchConfig config = ETLBatchConfig.builder("* * * * *")
       .addStage(source)
@@ -202,7 +203,7 @@ public class ExcelInputReaderTest extends ETLTestBase {
     DataSetManager<KeyValueTable> dataSetManager = getKVTableDataset("trackmemorytablereprocessfalse");
     KeyValueTable keyValueTable = dataSetManager.get();
     String excelTestFileTwo = "civil_test_data_two.xlsx";
-    File testFile = new File(sourcePath , excelTestFileTwo);
+    File testFile = new File(sourcePath, excelTestFileTwo);
     keyValueTable.write(testFile.toURI().toString(), String.valueOf(System.currentTimeMillis()));
     dataSetManager.flush();
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/XMLReaderTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/XMLReaderTest.java
@@ -85,7 +85,8 @@ public class XMLReaderTest extends ETLTestBase {
     serviceURL = serviceManager.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     URL url = new URL(serviceURL, "xmlreadersource/create");
     //POST request to create a new file set with name xmlreadersource.
-    HttpResponse response = getRestClient().execute(HttpMethod.POST, url, getClientConfig().getAccessToken());
+    HttpResponse response = getRestClient()
+      .execute(HttpRequest.post(url).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
     url = new URL(serviceURL, "xmlreadersource?path=catalog.xml");
     //PUT request to upload the catalog.xml file, sent in the request body
@@ -98,7 +99,7 @@ public class XMLReaderTest extends ETLTestBase {
 
     url = new URL(serviceURL, "xmlreadertarget/create");
     //POST request to create a new file set with name xmlreadertarget.
-    response = getRestClient().execute(HttpMethod.POST, url, getClientConfig().getAccessToken());
+    response = getRestClient().execute(HttpRequest.post(url).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
 
     //GET location of the fileset xmlreadersource on cluster.

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/realtime/DataStreamsTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/realtime/DataStreamsTest.java
@@ -77,7 +77,8 @@ public class DataStreamsTest extends ETLTestBase {
 
     URL url = new URL(serviceURL, "testFileSet/create");
     //POST request to create a new file set with name testFileSet.
-    HttpResponse response = getRestClient().execute(HttpMethod.POST, url, getClientConfig().getAccessToken());
+    HttpResponse response = getRestClient()
+      .execute(HttpRequest.post(url).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
 
     URL pathServiceUrl = new URL(serviceURL, "testFileSet?path");

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/wrangler/WranglerServiceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/wrangler/WranglerServiceTest.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.ServiceManager;
 import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Test;
@@ -146,8 +147,9 @@ public class WranglerServiceTest extends ETLTestBase {
 
   private void createAndUploadWorkspace(URL baseURL, List<String> lines) throws Exception {
     String workspacePath = String.format("contexts/%s/workspaces/%s", TEST_NAMESPACE.getNamespace(), WORKSPACE_NAME);
-    HttpResponse response = getRestClient().execute(HttpMethod.PUT, new URL(baseURL, workspacePath),
-                                                    getClientConfig().getAccessToken());
+    HttpResponse response = getRestClient()
+      .execute(HttpRequest.put(new URL(baseURL, workspacePath)).withBody("").build(),
+               getClientConfig().getAccessToken());
     Assert.assertEquals(200, response.getResponseCode());
 
     String body = Joiner.on(URLEncoder.encode("\n", StandardCharsets.UTF_8.name())).join(lines);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/serviceworker/ServiceWorkerTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/serviceworker/ServiceWorkerTest.java
@@ -94,7 +94,8 @@ public class ServiceWorkerTest extends AudiTestBase {
     } catch (Throwable expected) {
       expected = Throwables.getRootCause(expected);
       Assert.assertTrue(expected.getMessage().startsWith("409: "));
-      Assert.assertTrue(expected.getMessage().contains(ServiceApplication.SERVICE_NAME + " is already running"));
+      // Shouldnt asset on error message anymore since IVP masks the error messages
+//      Assert.assertTrue(expected.getMessage().contains(ServiceApplication.SERVICE_NAME + " is already running"));
     }
 
     serviceManager.stop();

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/ApplicationTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/ApplicationTest.java
@@ -28,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests functionality of Applications
@@ -48,7 +47,8 @@ public class ApplicationTest extends AudiTestBase {
       Assert.fail();
     } catch (IOException expected) {
       Assert.assertTrue(expected.getMessage().startsWith("409"));
-      Assert.assertTrue(expected.getMessage().contains("FileSetService"));
+      // Shouldnt asset on error message anymore since IVP masks the error messages
+//      Assert.assertTrue(expected.getMessage().contains("FileSetService"));
     }
 
     // should not delete non-existing application

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/NamespaceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/NamespaceTest.java
@@ -78,16 +78,20 @@ public class NamespaceTest extends AudiTestBase {
     // shouldn't allow creation of default or system namespace
     try {
       namespaceClient.create(NamespaceMeta.DEFAULT);
+      Assert.fail();
     } catch (BadRequestException expected) {
-      Assert.assertTrue(expected.getMessage().contains(String.format("'%s' is a reserved namespace",
-                                                                     NamespaceId.DEFAULT.getNamespace())));
+      // Shouldnt asset on error message anymore since IVP masks the error messages
+//      Assert.assertTrue(expected.getMessage().contains(String.format("'%s' is a reserved namespace",
+//                                                                     NamespaceId.DEFAULT.getNamespace())));
     }
 
     try {
       namespaceClient.create(new NamespaceMeta.Builder().setName(NamespaceId.SYSTEM).build());
+      Assert.fail();
     } catch (BadRequestException expected) {
-      Assert.assertTrue(expected.getMessage().contains(String.format("'%s' is a reserved namespace",
-                                                                     NamespaceId.SYSTEM.getNamespace())));
+      // Shouldnt asset on error message anymore since IVP masks the error messages
+//      Assert.assertTrue(expected.getMessage().contains(String.format("'%s' is a reserved namespace",
+//                                                                     NamespaceId.SYSTEM.getNamespace())));
     }
 
     // zero out generation so that it's not used in comparison

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionCorrectorTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionCorrectorTest.java
@@ -51,8 +51,9 @@ public class PartitionCorrectorTest extends AudiTestBase {
     URL serviceURL = pfsService.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     for (int i = 0; i < 100; i++) {
-      HttpResponse response = getRestClient().execute(HttpRequest.put(new URL(serviceURL, String.valueOf(i))).build(),
-                                                      getClientConfig().getAccessToken());
+      HttpResponse response = getRestClient()
+        .execute(HttpRequest.put(new URL(serviceURL, String.valueOf(i))).withBody("").build(),
+                 getClientConfig().getAccessToken());
       Assert.assertEquals(200, response.getResponseCode());
     }
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionedFileSetUpdateTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionedFileSetUpdateTest.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.AudiTestBase;
 import io.cdap.cdap.test.ServiceManager;
 import io.cdap.cdap.test.WorkerManager;
-import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
@@ -63,12 +62,14 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
     startAndWaitForRun(pfsService, ProgramRunStatus.RUNNING);
     URL serviceURL = pfsService.getServiceURL(PROGRAM_START_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-    HttpResponse response = getRestClient().execute(HttpRequest.put(new URL(serviceURL, "1")).build(),
+    HttpResponse response = getRestClient().execute(HttpRequest.put(new URL(serviceURL, "1")).withBody("").build(),
                                                     getClientConfig().getAccessToken());
     Assert.assertEquals(200, response.getResponseCode());
-    response = getRestClient().execute(HttpMethod.PUT, new URL(serviceURL, "2"), getClientConfig().getAccessToken());
+    response = getRestClient()
+      .execute(HttpRequest.put(new URL(serviceURL, "2")).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(200, response.getResponseCode());
-    response = getRestClient().execute(HttpMethod.PUT, new URL(serviceURL, "3"), getClientConfig().getAccessToken());
+    response = getRestClient()
+      .execute(HttpRequest.put(new URL(serviceURL, "3")).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(200, response.getResponseCode());
 
     DatasetClient datasetClient = new DatasetClient(getClientConfig(), getRestClient());
@@ -101,7 +102,8 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
     validate(client, "i", "j", 3, 3);
 
     // add a new partition and validate that the delimiter change applied to it
-    response = getRestClient().execute(HttpMethod.PUT, new URL(serviceURL, "4"), getClientConfig().getAccessToken());
+    response = getRestClient()
+      .execute(HttpRequest.put(new URL(serviceURL, "4")).withBody("").build(), getClientConfig().getAccessToken());
     Assert.assertEquals(200, response.getResponseCode());
 
     validate(client, "i", "j", 3, 4);
@@ -114,12 +116,12 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
   }
 
   /**
-   * This validates that the pfs has all data in the correct format. Assumes that the pfs has a hybrid set
-   * of partitions, up to a certain partition key (commaLimit) delimited by comma, thereafter delimited by :
+   * This validates that the pfs has all data in the correct format. Assumes that the pfs has a hybrid set of
+   * partitions, up to a certain partition key (commaLimit) delimited by comma, thereafter delimited by :
    *
    * @param client a query client
    * @param fieldA the name of the first field in the explore table schema
-   * @param fieldB  the name of the second field in the explore table schema
+   * @param fieldB the name of the second field in the explore table schema
    * @param commaLimit partitions from key=1 up to key=commaLimit (inclusive) have ',' as the delimiter
    * @param colonLimit partitions with key>commaLimit up to key=colonLimit have ':' as the delimiter
    */
@@ -171,5 +173,4 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
     }
     return rows;
   }
-
 }


### PR DESCRIPTION
New ITN system was throwing errors because some post/put errors did not set the `content-length` header. I updated the tests to include an empty string as body to set the length header in the request.

Also removed Assert checks on exact error messages but left checks on error codes