### PR TITLE
Disable tests that use explore functionality

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ETLMapReduceTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/ETLMapReduceTest.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.test.DataSetManager;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.common.Properties;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -111,6 +112,8 @@ public class ETLMapReduceTest extends ETLTestBase {
     }
   }
 
+  // TODO: (CDAP-17727) fix and un-ignore
+  @Ignore
   @Test
   public void testDAG() throws Exception {
     /*
@@ -325,6 +328,8 @@ public class ETLMapReduceTest extends ETLTestBase {
     deployApplication(appId, appRequest);
   }
 
+  // TODO: (CDAP-17727) fix and un-ignore
+  @Ignore
   @Test
   public void testDAGSchemaChanges() throws Exception {
 

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/HivePluginTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/batch/HivePluginTest.java
@@ -46,6 +46,7 @@ import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -71,6 +72,8 @@ public class HivePluginTest extends ETLTestBase {
     Lists.newArrayList("Hello World", "My Hello Hello World", "World Hello");
   private static final String DATA_UPLOAD = Joiner.on("\n").join(DATA_LIST);
 
+  // Skip explore tests
+  @Ignore
   @Test
   public void testHivePlugins() throws Exception {
     installPluginFromHub("hydrator-plugin-hive", "hive-plugins", "1.8.0-1.1.0");

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionCorrectorTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionCorrectorTest.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.test.WorkerManager;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.URL;
@@ -42,6 +43,8 @@ import java.util.concurrent.TimeoutException;
  */
 public class PartitionCorrectorTest extends AudiTestBase {
 
+  // Skip explore tests
+  @Ignore
   @Test
   public void test() throws Exception {
     ApplicationManager applicationManager = deployApplication(PFSApp.class);

--- a/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionedFileSetUpdateTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/apps/fileset/PartitionedFileSetUpdateTest.java
@@ -37,6 +37,7 @@ import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,8 @@ public class PartitionedFileSetUpdateTest extends AudiTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(PartitionedFileSetUpdateTest.class);
 
+  // Skip explore tests
+  @Ignore
   @Test
   public void test() throws Exception {
     ApplicationManager applicationManager = deployApplication(PFSApp.class);


### PR DESCRIPTION
Explore relies on an old Hive version and isn't being used now.