### PR TITLE
Fix GCSTest.testCreateFileMarkerOnPipelineFailure

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GCSTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/GCSTest.java
@@ -578,6 +578,7 @@ public class GCSTest extends DataprocETLTestBase {
       .put("project", "${project}")
       .put("path", "${marker_file_path}")
       .put("runCondition", runCondition)
+      .put("serviceFilePath", "auto-detect")
       .build();
 
     ETLPlugin markerFilePostActionPlugin = new ETLPlugin(


### PR DESCRIPTION
This test has the same service account path issue that was addressed in #1106 but it was missed in that PR.