### PR TITLE
CDAP-18718: Increasing wait time for pipeline completion

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -127,7 +127,7 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     Map<String, String> fullArgs = new HashMap<>();
     fullArgs.put("system.profile.name", getProfileName());
     fullArgs.putAll(args);
-    startAndWaitForRun(workflowManager, expectedStatus, fullArgs, 15, TimeUnit.MINUTES);
+    startAndWaitForRun(workflowManager, expectedStatus, fullArgs, 30, TimeUnit.MINUTES);
   }
 
   protected static String getServiceAccountCredentials() {


### PR DESCRIPTION
Integration tests are currently failing because of pipeline taking longer time to complete. The longer duration is causing the tests to timeout and not wait for pipeline completion. This is creating cascading issues as the dataproc profile cannot be cleaned up after the test has run.

Increasing wait time for pipeline completion as a short term fix.