### PR TITLE
Enable PubSubTests

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/PubSubTest.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/PubSubTest.java
@@ -98,8 +98,6 @@ import java.util.concurrent.TimeUnit;
  * for more details
  */
 
-// TODO - Enable it after fixing not to use FileSetDataset. See CDAP-18241.
-@Ignore
 public class PubSubTest extends DataprocETLTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(PubSubTest.class);
   private static final String GOOGLE_SUBSCRIBER_PLUGIN_NAME = "GoogleSubscriber";


### PR DESCRIPTION
PubSubTest was disabled because of the below error
```
2021-07-16 17:09:49,074 - ERROR [Driver:o.a.s.d.y.ApplicationMaster@94] - User class threw exception: java.lang.NoClassDefFoundError: org/apache/hadoop/hdfs/HAUtil
java.lang.NoClassDefFoundError: org/apache/hadoop/hdfs/HAUtil
	at org.apache.twill.filesystem.FileContextLocationUtil.lookupInHAUtil(FileContextLocationUtil.java:42) ~[org.apache.twill.twill-yarn-0.14.0.jar:0.14.0]
	at org.apache.twill.filesystem.FileContextLocationUtil.<clinit>(FileContextLocationUtil.java:52) ~[org.apache.twill.twill-yarn-0.14.0.jar:0.14.0]
```
The issue is now fixed so re-enabling this test.
Jira - https://cdap.atlassian.net/browse/CDAP-18241