### PR TITLE
Add serviceAccount property to Dataproc profile

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -61,6 +61,7 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
 
   private static String projectId;
   private static String serviceAccountCredentials;
+  private static String serviceAccountEmail;
   private static String network;
   private static int workerCPUs;
   private static int workerMemMB;
@@ -84,6 +85,7 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
 
     JsonObject serviceAccountJson = new JsonParser().parse(serviceAccountCredentials).getAsJsonObject();
     projectId = serviceAccountJson.get("project_id").getAsString();
+    serviceAccountEmail = serviceAccountJson.get("client_email").getAsString();
 
     network = System.getProperty("google.dataproc.network", "default");
     workerCPUs = Integer.parseInt(System.getProperty("google.dataproc.worker.cpu", "4"));
@@ -151,6 +153,10 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     return projectId;
   }
 
+  protected static String getServiceAccountEmail() {
+    return serviceAccountEmail;
+  }
+
   protected abstract void innerSetup() throws Exception;
 
   protected abstract void innerTearDown() throws Exception;
@@ -159,7 +165,7 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     Gson gson = new Gson();
     JsonArray properties = new JsonArray();
     properties.add(ofProperty("accountKey", getServiceAccountCredentials()));
-    properties.add(ofProperty("serviceAccount", getServiceAccountCredentials()));
+    properties.add(ofProperty("serviceAccount", getServiceAccountEmail()));
     properties.add(ofProperty("network", network));
     properties.add(ofProperty("region", "us-central1"));
     properties.add(ofProperty("projectId", getProjectId()));

--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -159,6 +159,7 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     Gson gson = new Gson();
     JsonArray properties = new JsonArray();
     properties.add(ofProperty("accountKey", getServiceAccountCredentials()));
+    properties.add(ofProperty("serviceAccount", getServiceAccountCredentials()));
     properties.add(ofProperty("network", network));
     properties.add(ofProperty("region", "us-central1"));
     properties.add(ofProperty("projectId", getProjectId()));


### PR DESCRIPTION
### Issue:
Dataproc clusters created to run the integration tests use default compute engine service account, which has excessive permissions. 

### Change:
Add service account property to dataproc profile created for running pipelines.