### PR TITLE
Update cdap version to 6.7.3-SNAPSHOT to get updated cdap-cli dependency which fixes test flakiness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <bigtable.version>1.8.0</bigtable.version>
     <cdap.pre.version>6.2.3</cdap.pre.version>
-    <cdap.version>6.7.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.7.3-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.9.0-SNAPSHOT</cdap.plugin.version>
     <!-- cdap.examples.version is overridden in the pre-stage of upgrade tests -->
     <cdap.examples.version>${cdap.version}</cdap.examples.version>


### PR DESCRIPTION
cdap-cli 6.7.3-SNAPSHOT has changes to ProgramClient from https://github.com/cdapio/cdap/pull/14935