### PR TITLE
Revert "Skip cluster deletion to prevent long-running tests bottlenecked by Dataproc cluster creation time"

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -182,7 +182,6 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     properties.add(ofProperty("stackdriverLoggingEnabled", "true"));
     properties.add(ofProperty("stackdriverMonitoringEnabled", "true"));
     properties.add(ofProperty("idleTTL", "60"));
-    properties.add(ofProperty("skipDelete", "true"));
 
     JsonObject provisioner = new JsonObject();
     provisioner.addProperty("name", "gcp-dataproc");


### PR DESCRIPTION
Reverts cdapio/cdap-integration-tests#1240

This does not work due to https://cdap.atlassian.net/browse/CDAP-20782.