### PR TITLE
Switch remote tests to use e2 machine types

### DIFF
--- a/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
+++ b/integration-test-remote/src/test/java/io/cdap/cdap/app/etl/gcp/DataprocETLTestBase.java
@@ -158,10 +158,12 @@ public abstract class DataprocETLTestBase extends ETLTestBase {
     properties.add(ofProperty("projectId", getProjectId()));
 
     properties.add(ofProperty("masterNumNodes", "1"));
+    properties.add(ofProperty("masterMachineType", "e2"));
     properties.add(ofProperty("masterCPUs", "2"));
     properties.add(ofProperty("masterMemoryMB", "8192"));
     properties.add(ofProperty("masterDiskGB", "1000"));
     properties.add(ofProperty("workerNumNodes", String.valueOf(workerCount)));
+    properties.add(ofProperty("workerMachineType", "e2"));
     properties.add(ofProperty("workerCPUs", String.valueOf(workerCPUs)));
     properties.add(ofProperty("workerMemoryMB", String.valueOf(workerMemMB)));
     properties.add(ofProperty("workerDiskGB", "500"));


### PR DESCRIPTION
Switch remote tests to use e2 machine types
cherry-pick #1244